### PR TITLE
#237 Single enable sdk locator checkbox

### DIFF
--- a/dpAutoRigSystem/Modules/dpLayoutClass.py
+++ b/dpAutoRigSystem/Modules/dpLayoutClass.py
@@ -242,6 +242,7 @@ class LayoutClass:
                     cmds.text(" ", parent=self.sdkLocatorLayout)
                     sdkLocatorValue = cmds.getAttr(self.moduleGrp+".sdkLocator")
                     self.sdkLocatorCB = cmds.checkBox(label="SDK Locator", value=sdkLocatorValue, enable=False, changeCommand=self.changeSDKLocator, parent=self.sdkLocatorLayout)
+                    self.changeIndirectSkin()
                     
                 # create eyelid layout:
                 if self.eyelidExists:

--- a/dpAutoRigSystem/Modules/dpSingle.py
+++ b/dpAutoRigSystem/Modules/dpSingle.py
@@ -57,7 +57,7 @@ class Single(Base.StartClass, Layout.LayoutClass):
         cmds.addAttr(self.moduleGrp, longName='holder', attributeType='bool')
         cmds.setAttr(self.moduleGrp+".holder", 0)
         cmds.addAttr(self.moduleGrp, longName='sdkLocator', attributeType='bool')
-        cmds.setAttr(self.moduleGrp+".sdkLocator", 1)
+        cmds.setAttr(self.moduleGrp+".sdkLocator", 0)
         
         cmds.setAttr(self.moduleGrp+".moduleNamespace", self.moduleGrp[:self.moduleGrp.rfind(":")], type='string')
         

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -20,8 +20,8 @@
 
 
 # current version:
-DPAR_VERSION = "3.10.30"
-DPAR_UPDATELOG = "#235 Single extra SDK locator."
+DPAR_VERSION = "3.10.31"
+DPAR_UPDATELOG = "#237 Enable extra SDK locator checkbox."
 
 
 


### PR DESCRIPTION
Just a simple UI fix to enable sdk locator checkbox when realoading Single module layout.
Also changed the sdkLocator value to zero when we create the Single module. This affects and it is automatic applied to create integrated script by Tweaks module.