### PR TITLE
#283 Fixed Head invertRot variable

### DIFF
--- a/dpAutoRigSystem/Modules/dpHead.py
+++ b/dpAutoRigSystem/Modules/dpHead.py
@@ -547,17 +547,17 @@ class Head(Base.StartClass, Layout.LayoutClass):
                 
                 # setup jaw move:
                 # jaw open:
-                self.setupJawMove(self.jawCtrl, "c108_open", True, "Y", "c049_intensity", createOutput=True, *args)
-                self.setupJawMove(self.jawCtrl, "c108_open", True, "Z", "c049_intensity", *args)
+                self.setupJawMove(self.jawCtrl, "c108_open", True, "Y", "c049_intensity", createOutput=True)
+                self.setupJawMove(self.jawCtrl, "c108_open", True, "Z", "c049_intensity")
                 # jaw close:
-                self.setupJawMove(self.jawCtrl, "c109_close", False, "Y", "c049_intensity", createOutput=True, *args)
-                self.setupJawMove(self.jawCtrl, "c109_close", False, "Z", "c049_intensity", *args)
+                self.setupJawMove(self.jawCtrl, "c109_close", False, "Y", "c049_intensity", createOutput=True)
+                self.setupJawMove(self.jawCtrl, "c109_close", False, "Z", "c049_intensity")
                 # upper lid close:
-                self.setupJawMove(self.upperLipCtrl, "c109_close", False, "Y", "c039_lip", *args)
-                self.setupJawMove(self.upperLipCtrl, "c109_close", False, "Z", "c039_lip", *args)
+                self.setupJawMove(self.upperLipCtrl, "c109_close", False, "Y", "c039_lip")
+                self.setupJawMove(self.upperLipCtrl, "c109_close", False, "Z", "c039_lip")
                 # lower lid close:
-                self.setupJawMove(self.lowerLipCtrl, "c109_close", False, "Y", "c039_lip", invertRot=True, *args)
-                self.setupJawMove(self.lowerLipCtrl, "c109_close", False, "Z", "c039_lip", *args)
+                self.setupJawMove(self.lowerLipCtrl, "c109_close", False, "Y", "c039_lip", invertRot=True)
+                self.setupJawMove(self.lowerLipCtrl, "c109_close", False, "Z", "c039_lip")
                 
                 # set jaw move and lips calibrate default values:
                 cmds.setAttr(self.jawCtrl+"."+self.langDic[self.langName]['c108_open'].lower()+self.langDic[self.langName]['c110_start'].capitalize()+"Rotation", 5)

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -20,8 +20,8 @@
 
 
 # current version:
-DPAR_VERSION = "3.11.05"
-DPAR_UPDATELOG = "#282 Dimond curve shape.\nRenamed old Dimond to Dimond Flat."
+DPAR_VERSION = "3.11.06"
+DPAR_UPDATELOG = "#283 Fixed Head error about invertRot variable."
 
 
 


### PR DESCRIPTION
#283 fixed Head error when calling setupJawMove method passing *args. Just removed *args to work.
Thanks Caio for the feedback.

Co-Authored-By: caiolubel <7073504+caiolubel@users.noreply.github.com>