### PR TITLE
#176 Finger stretchable

### DIFF
--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -20,8 +20,8 @@
 
 
 # current version:
-DPAR_VERSION = "3.11.14"
-DPAR_UPDATELOG = "#148 AutoClavicle world matrix fix."
+DPAR_VERSION = "3.11.15"
+DPAR_UPDATELOG = "#176 Finger stretchable fix."
 
 
 


### PR DESCRIPTION
Fixed #176 finger stretchable.
The issue was about the joints scale compensate attribute.
We added a new attribute in the Main Control to change joint scale compensate attributes.
Now the stretch first null transform position starts at the main control position instead of the first joint zero.
Fixed the ikCtrl orientation too.