### PR TITLE
#154 Replace control shape order

### DIFF
--- a/dpAutoRigSystem/Extras/sqCopyPasteShapes.py
+++ b/dpAutoRigSystem/Extras/sqCopyPasteShapes.py
@@ -67,12 +67,24 @@ def fetch_ctrl_shapes(source, target):
     """
     # Remove any previous shapes
     pymel.delete(filter(lambda x: isinstance(x, pymel.nodetypes.CurveShape), target.getShapes()))
+
+    # Working with shape order trying to keep the shape as the first child node of the transform
+    childrenGrp = None
+    children = target.getChildren()
+    if children:
+        childrenGrp = pymel.group(children, name='dpTemp_DestChildren_Grp')
+        pymel.parent(childrenGrp, world=True)
+    
     for source_shape in source.getShapes():
         shape_snapshot = _duplicate_shape(source_shape)
         tmp_transform = shape_snapshot.getParent()
         shape_snapshot.setParent(target, r=True, s=True)
         shape_snapshot.rename(target.name() + 'Shape')
         pymel.delete(tmp_transform)
+
+    if children:
+        pymel.parent(children, target)
+        pymel.delete(childrenGrp)
 
     # TODO: Restore AnnotationShapes
     #pymel.delete(source)
@@ -169,8 +181,8 @@ ICON = "/Icons/dp_copyPasteShapes.png"
 
 class CopyPasteShapes():
     def __init__(self, *args, **kwargs):
-        if cmds.window("CopyPasteShapes", query=True, exists=True):
-            cmds.deleteUI("CopyPasteShapes")
+        if cmds.window("sqCopyPasteShapesWindow", query=True, exists=True):
+            cmds.deleteUI("sqCopyPasteShapesWindow")
 
         win = cmds.window('sqCopyPasteShapesWindow', title='CopyPasteShapes', widthHeight=(200, 100), menuBar=False, sizeable=True, minimizeButton=True, maximizeButton=False, menuBarVisible=False, titleBar=True)
         layout = cmds.columnLayout('sqCopyPasteShapesLayout', adjustableColumn=True, parent=win)

--- a/dpAutoRigSystem/Modules/Library/dpControls.py
+++ b/dpAutoRigSystem/Modules/Library/dpControls.py
@@ -634,6 +634,11 @@ class ControlClass:
                                     break
                             if clearDestinationShapes:
                                 cmds.delete(destShapeList)
+                        # hack: unparent destination children in order to get a good shape hierarchy order as index 0:
+                        destChildrenList = cmds.listRelatives(destTransform, shapes=False, type="transform", fullPath=True)
+                        if destChildrenList:
+                            self.destChildrenGrp = cmds.group(destChildrenList, name="dpTemp_DestChildren_Grp")
+                            cmds.parent(self.destChildrenGrp, world=True)
                         dupSourceShapeList = cmds.listRelatives(dupSourceItem, shapes=True, type="nurbsCurve", fullPath=True)
                         for dupSourceShape in dupSourceShapeList:
                             if needKeepVis:
@@ -641,6 +646,10 @@ class ControlClass:
                             cmds.parent(dupSourceShape, destTransform, relative=True, shape=True)
                         cmds.delete(dupSourceItem)
                         self.renameShape([destTransform])
+                        # restore children transforms to correct parent hierarchy:
+                        if destChildrenList:
+                            cmds.parent((cmds.listRelatives(self.destChildrenGrp, shapes=False, type="transform", fullPath=True)), destTransform)
+                            cmds.delete(self.destChildrenGrp)
                     if deleteSource:
                         # update cvControls attributes:
                         self.transferAttr(sourceItem, destinationList, ["className", "size", "degree", "cvRotX", "cvRotY", "cvRotZ"])

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -20,8 +20,8 @@
 
 
 # current version:
-DPAR_VERSION = "3.11.17"
-DPAR_UPDATELOG = "#267 Facial control Z axis:\n\nRedefined targets lists to:\nLips: R_LipsSide, L_LipsSide, LipsUp, LipsDown, LipsBack, LipsFront\nFace: added Pucker and BigSmile.\n#268 Lips Control target redesign\n#269 Face Control new attributes.\n#158	BigSmile target."
+DPAR_VERSION = "3.11.18"
+DPAR_UPDATELOG = "#154 Replace control shapes order.\nIt'll keep the curve shapes as the first child\nto maintain Maya hierarchy working well\nusing keyboard arrows."
 
 
 


### PR DESCRIPTION
Keep replaced control shape as the first child of the transform.
Then, we'll use keyboard arrows respecting Maya hierarchy structure by default.