### PR TITLE
#162 replace connected shape

### DIFF
--- a/dpAutoRigSystem/Extras/sqCopyPasteShapes.py
+++ b/dpAutoRigSystem/Extras/sqCopyPasteShapes.py
@@ -96,7 +96,7 @@ def hold_all_ctrls_shapes(**kwargs):
     ctrls = get_all_ctrls()
     return [hold_ctrl_shapes(oCtrl, **kwargs) for oCtrl in ctrls]
 
-# TODO: Fix bug when two objects have the same name.
+
 def fetch_all_ctrls_shapes():
     """
     Restore the snapshots of all shapes of all ctrls.
@@ -105,13 +105,15 @@ def fetch_all_ctrls_shapes():
 
     for oSource in aSources:
         sTargetName = oSource.name()[:-8]
-        if pymel.objExists(sTargetName):
-            oTarget = pymel.PyNode(str(sTargetName))
+        if len(cmds.ls(sTargetName)) == 1:
+            if pymel.objExists(sTargetName):
+                oTarget = pymel.PyNode(str(sTargetName))
 
-            fetch_ctrl_shapes(oSource, oTarget)
-            #pymel.delete(oSource)
+                fetch_ctrl_shapes(oSource, oTarget)
+            else:
+                pymel.warning("Can't find {0}".format(sTargetName))
         else:
-            pymel.warning("Can't find {0}".format(sTargetName))
+            pymel.warning("Skipped: more than one object named {0}".format(sTargetName))
 
 def get_default_path_snapshot(current_path=None):
     if current_path is None:

--- a/dpAutoRigSystem/Extras/sqCopyPasteShapes.py
+++ b/dpAutoRigSystem/Extras/sqCopyPasteShapes.py
@@ -191,10 +191,13 @@ class CopyPasteShapes():
         cmds.showWindow(win)
 
     def onBtnSavePressed(self, state):
-        path = cmds.fileDialog2(fileMode=0, caption="Safe Shapes")
+        path = cmds.fileDialog2(fileMode=0, caption="Save Shapes")
         if not path:
             return
         path = next(iter(path), None)
+        # make sure we save the file as mayaAscii
+        if not path.endswith(".ma"):
+            path = path.replace(".*", ".ma")
         save_all_ctrls_shapes(path)
 
     def onBtnLoadPressed(self, state):

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -20,8 +20,8 @@
 
 
 # current version:
-DPAR_VERSION = "3.11.22"
-DPAR_UPDATELOG = "#162 - Replace connected shape.\nThis is useful to keep visibility connections\nwhen replacing control shapes like\nSpine and reverseFoot."
+DPAR_VERSION = "3.11.23"
+DPAR_UPDATELOG = "#162 - Replace connected shape.\nThis is useful to keep visibility connections\nwhen replacing control shapes like\nSpine and reverseFoot.\n\n#317 Fixed duplicated object name.\n\n#324 Continue if not found control to replace shape.\n\nAlso fixed save file as mayaAscii."
 
 
 

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -21,7 +21,7 @@
 
 # current version:
 DPAR_VERSION = "3.11.22"
-DPAR_UPDATELOG = "#295 - Nose side guide rotate fix."
+DPAR_UPDATELOG = "#162 - Replace connected shape.\nThis is useful to keep visibility connections\nwhen replacing control shapes like\nSpine and reverseFoot."
 
 
 


### PR DESCRIPTION
Updated sqCopyPasteShape extra module:
#162 - Replace shape and keep visibility connection.
#317 - Fixed Control Shape with same name bug.
#324 - Continue if not found control to replace.