### PR TITLE
N143 Head quadruped neck autoRotate fix

### DIFF
--- a/dpAutoRigSystem/Controls/Presets/Default.json
+++ b/dpAutoRigSystem/Controls/Presets/Default.json
@@ -2,7 +2,7 @@
     "_preset"     : "Default",
     "_author"     : "Danilo Pinheiro",
     "_date"       : "2019-12-03",
-    "_updated"    : "2021-07-23",
+    "_updated"    : "2021-07-25",
 
     "id_000_Base"            : {"type" : "Circle",           "degree" : 1},
     "id_001_Locator"         : {"type" : "Locator",          "degree" : 1},
@@ -26,7 +26,7 @@
     "id_019_FootReverseE"    : {"type" : "Circle",           "degree" : 3},
     "id_020_FootFk"          : {"type" : "Circle",           "degree" : 1},
     "id_021_FootMiddle"      : {"type" : "RoundUp",          "degree" : 3},
-    "id_022_HeadNeck"        : {"type" : "Circle",           "degree" : 3},
+    "id_022_HeadNeck"        : {"type" : "Drop",             "degree" : 3},
     "id_023_HeadHead"        : {"type" : "BallonFlat",       "degree" : 3},
     "id_024_HeadJaw"         : {"type" : "JawHandle",        "degree" : 3},
     "id_025_HeadChin"        : {"type" : "Square",           "degree" : 1},

--- a/dpAutoRigSystem/Modules/dpHead.py
+++ b/dpAutoRigSystem/Modules/dpHead.py
@@ -609,15 +609,15 @@ class Head(Base.StartClass, Layout.LayoutClass):
                     cmds.connectAttr(self.neckCtrlList[n]+"."+self.langDic[self.langName]['c047_autoRotate'], neckARMD+".input2Z", force=True)
                     cmds.connectAttr(neckARMD+".outputX", self.neckOrientGrp+".rotateX", force=True)
                     if self.rigType == Base.RigType.quadruped:
-                        cmds.connectAttr(neckARMD+".outputY", self.neckOrientGrp+".rotateZ", force=True)
-                        quadrupedRotYFixMD = cmds.createNode('multiplyDivide', name=self.neckCtrlList[n]+"_"+neckARMDName+"_YFix_MD")
-                        cmds.connectAttr(neckARMD+".outputZ", quadrupedRotYFixMD+".input1X", force=True)
-                        cmds.setAttr(quadrupedRotYFixMD+".input2X", -1)
-                        cmds.connectAttr(quadrupedRotYFixMD+".outputX", self.neckOrientGrp+".rotateY", force=True)
+                        cmds.connectAttr(neckARMD+".outputZ", self.neckOrientGrp+".rotateY", force=True)
+                        quadrupedRotYZFixMD = cmds.createNode('multiplyDivide', name=self.neckCtrlList[n]+"_"+neckARMDName+"_YZ_Fix_MD")
+                        cmds.connectAttr(neckARMD+".outputY", quadrupedRotYZFixMD+".input1X", force=True)
+                        cmds.setAttr(quadrupedRotYZFixMD+".input2X", -1)
+                        cmds.connectAttr(quadrupedRotYZFixMD+".outputX", self.neckOrientGrp+".rotateZ", force=True)
                     else:
                         cmds.connectAttr(neckARMD+".outputY", self.neckOrientGrp+".rotateY", force=True)
                         cmds.connectAttr(neckARMD+".outputZ", self.neckOrientGrp+".rotateZ", force=True)
-                        
+                
                 # mount controls hierarchy:
                 cmds.parent(self.zeroCtrlList[1], self.headCtrl, absolute=True) #upperJawCtrl
                 cmds.parent(self.zeroCtrlList[3], self.jawCtrl, absolute=True) #chinCtrl

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -20,8 +20,8 @@
 
 
 # current version:
-DPAR_VERSION = "3.11.26"
-DPAR_UPDATELOG = "#030 - Head neck joints."
+DPAR_VERSION = "3.11.27"
+DPAR_UPDATELOG = "#143 - Quadruped neck autoRotate fix."
 
 
 


### PR DESCRIPTION
N143 fixed Head quadruped neck autoRotate.
We changed the channel to be inverted, because quadruped head control has a different rotate order than biped.