### PR TITLE
N401 Migrate to Python 3

### DIFF
--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -19,8 +19,8 @@
 
 
 # current version:
-DPAR_VERSION_PY3 = "3.13.16"
-DPAR_UPDATELOG = "N401 - Migrate to Python3."
+DPAR_VERSION_PY3 = "4.00.00"
+DPAR_UPDATELOG = "N401 - Migration to Python3 done."
 
 
 


### PR DESCRIPTION
First Python 3 supported version for Maya 2022 or earlier.
Release candidate.