### PR TITLE
N372 Fixed Nostril joint label

### DIFF
--- a/dpAutoRigSystem/Modules/dpNose.py
+++ b/dpAutoRigSystem/Modules/dpNose.py
@@ -364,11 +364,11 @@ class Nose(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                 dpUtils.setJointLabel(self.middleJnt, s+jointLabelAdd, 18, self.userGuideName+"_%02d_"%(n+1)+self.langDic[self.langName]['c029_middle'])
                 dpUtils.setJointLabel(self.tipJnt, s+jointLabelAdd, 18, self.userGuideName+"_%02d_"%(n+2)+self.langDic[self.langName]['c120_tip'])
                 dpUtils.setJointLabel(self.bottomJnt, s+jointLabelAdd, 18, self.userGuideName+"_%02d_"%(n+2)+self.langDic[self.langName]['c100_bottom'])
-                dpUtils.setJointLabel(self.lSideJnt, 1, 18, self.userGuideName+"_%02d_L_"%(n+3)+self.langDic[self.langName]['c121_side'])
-                dpUtils.setJointLabel(self.rSideJnt, 2, 18, self.userGuideName+"_%02d_R_"%(n+3)+self.langDic[self.langName]['c121_side'])
+                dpUtils.setJointLabel(self.lSideJnt, 1, 18, self.userGuideName+"_%02d_"%(n+3)+self.langDic[self.langName]['c121_side'])
+                dpUtils.setJointLabel(self.rSideJnt, 2, 18, self.userGuideName+"_%02d_"%(n+3)+self.langDic[self.langName]['c121_side'])
                 if self.addNostril:
-                    dpUtils.setJointLabel(self.lNostrilJnt, 1, 18, self.userGuideName+"_%02d_L_"%(n+4)+self.langDic[self.langName]['m079_nostril'])
-                    dpUtils.setJointLabel(self.rNostrilJnt, 2, 18, self.userGuideName+"_%02d_R_"%(n+4)+self.langDic[self.langName]['m079_nostril'])
+                    dpUtils.setJointLabel(self.lNostrilJnt, 1, 18, self.userGuideName+"_%02d_"%(n+4)+self.langDic[self.langName]['m079_nostril'])
+                    dpUtils.setJointLabel(self.rNostrilJnt, 2, 18, self.userGuideName+"_%02d_"%(n+4)+self.langDic[self.langName]['m079_nostril'])
                 
                 # creating controls:
                 self.middleCtrl = self.ctrls.cvControl("id_076_NoseMiddle", ctrlName=middleCtrlName, r=(self.ctrlRadius), d=self.curveDegree)

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -19,8 +19,8 @@
 
 
 # current version:
-DPAR_VERSION_PY3 = "4.00.02"
-DPAR_UPDATELOG = "N406 - No PyMEL for dpPoseReader.\nAlso no Qt.\nCreated a new module to replace it\nnamed dpCorrectionManager."
+DPAR_VERSION_PY3 = "4.00.03"
+DPAR_UPDATELOG = "N372 - Nose side nostril joint label fix."
 
 
 


### PR DESCRIPTION
Just removed L-R names in the Nostril joint label to fix the mirror skinning weight issue.