### PR TITLE
N432- Limb added UseOriginalRotation attribute

### DIFF
--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -19,8 +19,8 @@
 
 
 # current version:
-DPAR_VERSION_PY3 = "4.00.06"
-DPAR_UPDATELOG = "N433 - Limb leg stretch volumeVariation fix."
+DPAR_VERSION_PY3 = "4.00.07"
+DPAR_UPDATELOG = "N432 - Added original rotate toggle attribute\nto control alignWorld Limb's module feature."
 
 
 


### PR DESCRIPTION
N432 - Added a new attribute named useOriginalRotation to Limb extrem controller to be able choose activate or not the alignWorld feature.
Thanks Roy for the script.

Co-Authored-By: Roy Nieterau <roy_nieterau@hotmail.com>