### PR TITLE
464 check existing imported guides

### DIFF
--- a/dpAutoRigSystem/Languages/English.json
+++ b/dpAutoRigSystem/Languages/English.json
@@ -5,7 +5,7 @@
     "_date"          : "2010-10-03",
     "_language"      : "English",
     "_translator"    : "Danilo Pinheiro",
-    "_updated"       : "2022-08-21",
+    "_updated"       : "2022-09-11",
 
     "a000_presentation" : "This is the first sentence to translate.\nPlease use the text field bellow to write your translated text.\n\nYou can use buttons to:\nBack and review your translation.\nSame to use the same text to your language.\nNext to apply your translated text and move forward.\n\nUse Enter (Return) to a new line.\nSome texts don't accept special characters.\nOthers have punctuation or nothing.\n\nLet's start! Thank you.",
 
@@ -365,7 +365,7 @@
     "i203_noFolderFile"    : "Not found folder or file to work with, sorry.",
     "i204_recharge"        : "Recharge",
     "i205_guide"           : "Guide",
-    "i206_removeNamespace" : "Found imported guide(s). Would you like to delete the namespace(s)?",
+    "i206_removeNamespace" : "Found imported guide. Would you like to delete the namespace?",
 
     "m001_fkLine"               : "Fk Line",
     "m002_fkLineDesc"           : "Fk Line Module Description:\n\nThis module creates a joint chain\nwith the number of joints desired.\n\nWhen rigged, the controls will be FK (forward kinematics).\n\nThis is useful to create tails, ears, hairs\nor simple controls to objects.",
@@ -576,7 +576,6 @@
     "m204_finish"               : "Finish",
     "m205_version"              : "Version",
     "m206_mergeNamespace"       : "Imported guides namespace merged with root",
-
 
     "p001_prefixText" : "Attention: The prefix text cannot start with number, whitespace or have special characters, sorry.",
     "p002_left"       : "L",

--- a/dpAutoRigSystem/Languages/English.json
+++ b/dpAutoRigSystem/Languages/English.json
@@ -365,6 +365,7 @@
     "i203_noFolderFile"    : "Not found folder or file to work with, sorry.",
     "i204_recharge"        : "Recharge",
     "i205_guide"           : "Guide",
+    "i206_removeNamespace" : "Found imported guides. Would you like to delete the namespace?",
 
     "m001_fkLine"               : "Fk Line",
     "m002_fkLineDesc"           : "Fk Line Module Description:\n\nThis module creates a joint chain\nwith the number of joints desired.\n\nWhen rigged, the controls will be FK (forward kinematics).\n\nThis is useful to create tails, ears, hairs\nor simple controls to objects.",

--- a/dpAutoRigSystem/Languages/English.json
+++ b/dpAutoRigSystem/Languages/English.json
@@ -365,7 +365,7 @@
     "i203_noFolderFile"    : "Not found folder or file to work with, sorry.",
     "i204_recharge"        : "Recharge",
     "i205_guide"           : "Guide",
-    "i206_removeNamespace" : "Found imported guides. Would you like to delete the namespace?",
+    "i206_removeNamespace" : "Found imported guide(s). Would you like to delete the namespace(s)?",
 
     "m001_fkLine"               : "Fk Line",
     "m002_fkLineDesc"           : "Fk Line Module Description:\n\nThis module creates a joint chain\nwith the number of joints desired.\n\nWhen rigged, the controls will be FK (forward kinematics).\n\nThis is useful to create tails, ears, hairs\nor simple controls to objects.",
@@ -575,6 +575,8 @@
     "m203_setChildGuides"       : "Setting child guides",
     "m204_finish"               : "Finish",
     "m205_version"              : "Version",
+    "m206_mergeNamespace"       : "Imported guides namespace merged with root",
+
 
     "p001_prefixText" : "Attention: The prefix text cannot start with number, whitespace or have special characters, sorry.",
     "p002_left"       : "L",

--- a/dpAutoRigSystem/Languages/Francais.json
+++ b/dpAutoRigSystem/Languages/Francais.json
@@ -365,7 +365,7 @@
     "i203_noFolderFile"    : "Ce n'est pas trouvé le dossier ou le fichier pour travailler avec, désolé.",
     "i204_recharge"        : "Récharger",
     "i205_guide"           : "Guide",
-    "i206_removeNamespace" : "Trouvé des guides importés. Souhaitez-vous supprimer l'espace de noms?",
+    "i206_removeNamespace" : "Trouvé des guide(s) importé(s). Souhaitez-vous supprimer l'espace de nom(s)?",
 
     "m001_fkLine"               : "Ligne Fk",
     "m002_fkLineDesc"           : "Description du module Ligne Fk:\n\nCe module crées une chaine de joints\navec le nombre de joints désiré.\n\nLorsque rigged, les contrôles seront FK (forward kinematics).\n\nCeci est utile pour créer des queues, des oreilles, des poils\nou des contrôles simples pour les objets.",
@@ -575,6 +575,7 @@
     "m203_setChildGuides"       : "Définition des guides enfants",
     "m204_finish"               : "Finir",
     "m205_version"              : "Vérsion",
+    "m206_mergeNamespace"       : "Namespace des importé guides fusionné avec Root",
 
     "p001_prefixText" : "Attention: Le préfixe ne peut pas commencer avec un numéro, un espace blanc ou des caractères spéciaux, désole.",
     "p002_left"       : "G",

--- a/dpAutoRigSystem/Languages/Francais.json
+++ b/dpAutoRigSystem/Languages/Francais.json
@@ -365,6 +365,7 @@
     "i203_noFolderFile"    : "Ce n'est pas trouvé le dossier ou le fichier pour travailler avec, désolé.",
     "i204_recharge"        : "Récharger",
     "i205_guide"           : "Guide",
+    "i206_removeNamespace" : "Trouvé des guides importés. Souhaitez-vous supprimer l'espace de noms?",
 
     "m001_fkLine"               : "Ligne Fk",
     "m002_fkLineDesc"           : "Description du module Ligne Fk:\n\nCe module crées une chaine de joints\navec le nombre de joints désiré.\n\nLorsque rigged, les contrôles seront FK (forward kinematics).\n\nCeci est utile pour créer des queues, des oreilles, des poils\nou des contrôles simples pour les objets.",

--- a/dpAutoRigSystem/Languages/Francais.json
+++ b/dpAutoRigSystem/Languages/Francais.json
@@ -5,7 +5,7 @@
     "_date"          : "2011-08-04",
     "_language"      : "Français",
     "_translator"    : "Marina Rüegger",
-    "_updated"       : "2022-08-21",
+    "_updated"       : "2022-09-11",
 
     "a000_presentation" : "Ceci est la première phrase à traduire.\nVeuillez utiliser le champ de texte ci-dessous pour rédiger votre texte traduit.\n\nVous pouvez utiliser des boutons pour:\nRetourner et réviser votre traduction.\nMême pour utiliser le même texte dans votre langue.\nSuivant pour appliquer votre texte traduit et avancer.\n\nUtilisez Enter (Return) pour avoir une nouvelle ligne.\nCertains textes n'acceptent pas des caractères spéciaux.\nD'autres ont la ponctuation ou rien.\n\nCommençons! Je vous remercie.",
     
@@ -365,7 +365,7 @@
     "i203_noFolderFile"    : "Ce n'est pas trouvé le dossier ou le fichier pour travailler avec, désolé.",
     "i204_recharge"        : "Récharger",
     "i205_guide"           : "Guide",
-    "i206_removeNamespace" : "Trouvé des guide(s) importé(s). Souhaitez-vous supprimer l'espace de nom(s)?",
+    "i206_removeNamespace" : "Trouvé des guides importées. Souhaitez-vous supprimer le namespace?",
 
     "m001_fkLine"               : "Ligne Fk",
     "m002_fkLineDesc"           : "Description du module Ligne Fk:\n\nCe module crées une chaine de joints\navec le nombre de joints désiré.\n\nLorsque rigged, les contrôles seront FK (forward kinematics).\n\nCeci est utile pour créer des queues, des oreilles, des poils\nou des contrôles simples pour les objets.",
@@ -575,7 +575,7 @@
     "m203_setChildGuides"       : "Définition des guides enfants",
     "m204_finish"               : "Finir",
     "m205_version"              : "Vérsion",
-    "m206_mergeNamespace"       : "Namespace des importé guides fusionné avec Root",
+    "m206_mergeNamespace"       : "Les namespaces des guides importées sont mergés dans le Root",
 
     "p001_prefixText" : "Attention: Le préfixe ne peut pas commencer avec un numéro, un espace blanc ou des caractères spéciaux, désole.",
     "p002_left"       : "G",

--- a/dpAutoRigSystem/Languages/Portugues.json
+++ b/dpAutoRigSystem/Languages/Portugues.json
@@ -365,7 +365,7 @@
     "i203_noFolderFile"    : "Não encontrado o diretório ou arquivo para trabalhar com ele, desculpe.",
     "i204_recharge"        : "Recarregar",
     "i205_guide"           : "Guia",
-    "i206_removeNamespace" : "Encontrado guia(s) importada(s). Gostaria de deletar o namespace(s)?",
+    "i206_removeNamespace" : "Encontrado guias importadas. Gostaria de deletar o namespace?",
 
     "m001_fkLine"               : "Linha Fk",
     "m002_fkLineDesc"           : "Descrição do Modulo Linha Fk:\n\nEsse modulo cria uma cadeia de joints\ncom o numero de joints desejado.\n\nQuando rigado, os controles serão FK (forward kinematics).\n\nEle é util para criar rabos, orelhas, cabelos\nou simples controles de objetos.",
@@ -576,8 +576,6 @@
     "m204_finish"               : "Finalizar",
     "m205_version"              : "Versão",
     "m206_mergeNamespace"       : "Namespaces das guias importadas mescaladas com Root",
-
-    
     
     "p001_prefixText" : "Atenção: O texto do prefixo não pode começar com números, espaço em branco ou ter caracteres especiais, desculpe.",
     "p002_left"       : "E",

--- a/dpAutoRigSystem/Languages/Portugues.json
+++ b/dpAutoRigSystem/Languages/Portugues.json
@@ -365,7 +365,7 @@
     "i203_noFolderFile"    : "Não encontrado o diretório ou arquivo para trabalhar com ele, desculpe.",
     "i204_recharge"        : "Recarregar",
     "i205_guide"           : "Guia",
-    "i206_removeNamespace" : "Encontrado guias importadas. Gostaria de deletar o namespace?",
+    "i206_removeNamespace" : "Encontrado guia(s) importada(s). Gostaria de deletar o namespace(s)?",
 
     "m001_fkLine"               : "Linha Fk",
     "m002_fkLineDesc"           : "Descrição do Modulo Linha Fk:\n\nEsse modulo cria uma cadeia de joints\ncom o numero de joints desejado.\n\nQuando rigado, os controles serão FK (forward kinematics).\n\nEle é util para criar rabos, orelhas, cabelos\nou simples controles de objetos.",
@@ -575,6 +575,8 @@
     "m203_setChildGuides"       : "Configurando guias filhas",
     "m204_finish"               : "Finalizar",
     "m205_version"              : "Versão",
+    "m206_mergeNamespace"       : "Namespaces das guias importadas mescaladas com Root",
+
     
     
     "p001_prefixText" : "Atenção: O texto do prefixo não pode começar com números, espaço em branco ou ter caracteres especiais, desculpe.",

--- a/dpAutoRigSystem/Languages/Portugues.json
+++ b/dpAutoRigSystem/Languages/Portugues.json
@@ -365,6 +365,7 @@
     "i203_noFolderFile"    : "Não encontrado o diretório ou arquivo para trabalhar com ele, desculpe.",
     "i204_recharge"        : "Recarregar",
     "i205_guide"           : "Guia",
+    "i206_removeNamespace" : "Encontrado guias importadas. Gostaria de deletar o namespace?",
 
     "m001_fkLine"               : "Linha Fk",
     "m002_fkLineDesc"           : "Descrição do Modulo Linha Fk:\n\nEsse modulo cria uma cadeia de joints\ncom o numero de joints desejado.\n\nQuando rigado, os controles serão FK (forward kinematics).\n\nEle é util para criar rabos, orelhas, cabelos\nou simples controles de objetos.",

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -1240,7 +1240,58 @@ class DP_AutoRig_UI(object):
         self.modulesToBeRiggedList = dpUtils.getModulesToBeRigged(self.moduleInstancesList)
         cmds.text(self.allUIs["footerAText"], edit=True, label=str(len(self.modulesToBeRiggedList)) +" "+ self.langDic[self.langName]['i005_footerA'])
     
+
+    def checkImportedGuides(self, *args):
+        """ This method will check if there's imported dpGuides in the scene and ask if the user wants to delete the namespace.
+        """
+        # check all namespaces and if it's dpAR guide:
+        cmds.namespace(setNamespace=':')
+        namespaceList = cmds.namespaceInfo(listOnlyNamespaces=True, recurse=True)
+        if namespaceList:
+            dpGuidesImportedList = []
+            for name in namespaceList:
+                if name != "UI" and name != "shared":
+                    if name.count(":") > 0:
+                        if name.find("_dpAR_") > 0:
+                            dpGuidesImportedList.append(name)
+            if dpGuidesImportedList:
+                yesTxt = self.langDic[self.langName]['i071_yes']
+                noTxt = self.langDic[self.langName]['i072_no']
+                # open dialog to confirm merge namespaces:
+                result = cmds.confirmDialog(title=self.langDic[self.langName]['i205_guide'], message=self.langDic[self.langName]['i206_removeNamespace'], 
+                                            button=[yesTxt, noTxt], defaultButton=yesTxt, cancelButton=noTxt, dismissString=noTxt)
+                if result == yesTxt:
+                    # get root and child namespaces and separate into two lists:
+                    rootNamespaceList = []
+                    self.guidesNamespaceList = []
+                    for guide in dpGuidesImportedList:
+                        splitName = guide.split(":")
+                        rootNamespaceList.append(splitName[0])
+                        self.guidesNamespaceList.append(splitName[1])
+                    # get local guides list
+                    localGuidesList = list(map(lambda guideModule : guideModule.moduleGrp, self.modulesToBeRiggedList))
+                    # merge duplicated Father's name root:    
+                    rootNamespaceList = list(set(rootNamespaceList))
+                    # merge namespace with Root
+                    for name in rootNamespaceList:
+                        cmds.namespace(removeNamespace=name, mergeNamespaceWithRoot=True )
+                        print(f"{self.langDic[self.langName]['m206_mergeNamespace']}: {name}")
+                    # populate all guides after import and create a list with all guides:
+                    self.populateCreatedGuideModules()
+                    allList = cmds.ls(selection=False, type="transform")
+                    guidesNameList = []
+                    if allList:
+                        for item in allList:
+                            if cmds.objExists(item+".guideBase"):
+                                if cmds.getAttr(item+".guideBase") == 1:
+                                    guidesNameList.append(item)
+                    # rename imported guides instances to avoid duplicated names:
+                    for idx in range(len(guidesNameList)):
+                        if guidesNameList[idx] not in localGuidesList:
+                            guideCustomName = cmds.getAttr(guidesNameList[idx]+".customName")
+                            self.modulesToBeRiggedList[idx].editUserName(guideCustomName)
     
+
     def setPrefix(self, *args):
         """ Get the text entered in the textField and change it to normal.
         """
@@ -2693,55 +2744,3 @@ class DP_AutoRig_UI(object):
             print(self.langDic[self.langName]['i029_skinNothing'])
 
     ###################### End: Skinning.
-
-
-    def checkImportedGuides(self, *args):
-        """ This scriptJob will check if there's dpGuides imported to the scene and ask if the user wants to delete the namespace.
-        """
-        # check all namespaces and if it's dpAR guide:
-        cmds.namespace(setNamespace=':')
-        namespaceList = cmds.namespaceInfo(listOnlyNamespaces=True, recurse=True)
-        if namespaceList:
-            dpGuidesImportedList = []
-            for name in namespaceList:
-                if name != "UI" and name != "shared":
-                    if name.count(":") > 0:
-                        if name.find("_dpAR_") > 0:
-                            dpGuidesImportedList.append(name)
-            if dpGuidesImportedList:
-                # open dialog to confirm merge namespaces:
-                result = cmds.confirmDialog( title=self.langDic[self.langName]['i205_guide'], message=self.langDic[self.langName]['i206_removeNamespace'], 
-                button=[self.langDic[self.langName]['i071_yes'],self.langDic[self.langName]['i072_no']], defaultButton=self.langDic[self.langName]['i071_yes'], 
-                cancelButton=self.langDic[self.langName]['i072_no'], dismissString=self.langDic[self.langName]['i072_no'] )
-                if result == self.langDic[self.langName]['i071_yes']:
-                    # get root and child namespaces and separate into two lists:
-                    rootNamespaceList = []
-                    self.guidesNamespaceList = []
-                    for guide in dpGuidesImportedList:
-                        splitName = guide.split(":")
-                        rootNamespaceList.append(splitName[0])
-                        self.guidesNamespaceList.append(splitName[1])
-                        print (f"Imported DP Guides: {splitName[1]}")
-                    # get local guides list
-                    localGuidesList = list(map(lambda guideModule : guideModule.moduleGrp, self.modulesToBeRiggedList))
-                    # merge duplicated Father's name root:    
-                    rootNamespaceList = list(set(rootNamespaceList))
-                    # merge namespace with Root
-                    for name in rootNamespaceList:
-                        cmds.namespace(removeNamespace=name, mergeNamespaceWithRoot=True )
-                        print(f"Namespace merged with root: {name}")
-                    # populate all guides after import and create a list with all guides:
-                    self.populateCreatedGuideModules()
-                    allList = cmds.ls(selection=False, type="transform")
-                    guidesNameList = []
-                    if allList:
-                        for item in allList:
-                            if cmds.objExists(item+".guideBase"):
-                                if cmds.getAttr(item+".guideBase") == 1:
-                                    guidesNameList.append(item)
-                    # rename imported guides instances to void duplicated names:
-                    for idx in range(len(guidesNameList)):
-                        if guidesNameList[idx] not in localGuidesList:
-                            guideCustomName = cmds.getAttr(guidesNameList[idx]+".customName")
-                            self.modulesToBeRiggedList[idx].editUserName(guideCustomName)
-                    mel.eval('print \"dpAR: '+self.langDic[self.langName]["m206_mergeNamespace"]+'\\n\";')


### PR DESCRIPTION
Added on dpAutoRig.py a function to check if there're dpGuides imported to the scene and ask if the user wants do delete the namespace. This function is called inside the function jobReloadUI(). When pressing to reload UI, the autoRig will also check for imported guides. When guides were imported, they will be renamed to avoid duplicated customNames.