### PR TITLE
N545 Fixed Limb autoClavicle follow issue

### DIFF
--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -19,8 +19,8 @@
 
 
 # current version:
-DPAR_VERSION_PY3 = "4.01.10"
-DPAR_UPDATELOG = "N539 - Corrective joints for Head."
+DPAR_VERSION_PY3 = "4.01.11"
+DPAR_UPDATELOG = "N545 - Limb autoClavicle follow issue."
 
 
 


### PR DESCRIPTION
Fixed Limb autoClavicle follow issue not orienting the scalable main group. Instead of that we just used the shoulder null group to orient the articulation joint. Shoulder null group was renamed to shoulder ref group, because it's now used to receive the Jax and Jar shoulder joints when we ask to have corrective joints.