### PR TITLE
N544 Jcr calibration by ctrlRadius

### DIFF
--- a/dpAutoRigSystem/Modules/dpBaseClass.py
+++ b/dpAutoRigSystem/Modules/dpBaseClass.py
@@ -305,7 +305,7 @@ class StartClass(object):
                     cmds.parent(jcrGrp, self.correctiveCtrlsGrp)
                     # preset calibration
                     for calibrateAttr in calibratePresetList[i].keys():
-                        cmds.setAttr(jcrCtrl+"."+calibrateAttr, calibratePresetList[i][calibrateAttr])
+                        cmds.setAttr(jcrCtrl+"."+calibrateAttr, calibratePresetList[i][calibrateAttr]*self.ctrlRadius)
                     if invertList:
                         invertAttrList = invertList[i]
                         if invertAttrList:

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -19,8 +19,8 @@
 
 
 # current version:
-DPAR_VERSION_PY3 = "4.01.12"
-DPAR_UPDATELOG = "N550 - Fixed joints corrective mirror calibration."
+DPAR_VERSION_PY3 = "4.01.13"
+DPAR_UPDATELOG = "N544 - Adjusted corrective joints calibration\nby guide radius."
 
 
 


### PR DESCRIPTION
Adjusted corrective joints calibration by control radius. Just multiplying the given preset calibration value to the module guide radius before set the calibrate attribute.