### PR TITLE
N428 Group naming

### DIFF
--- a/dpAutoRigSystem/Modules/Library/dpUtils.py
+++ b/dpAutoRigSystem/Modules/Library/dpUtils.py
@@ -518,7 +518,7 @@ def getModulesToBeRigged(instanceList):
             guideNamespaceName = guideModule.guideNamespace
             if guideNamespaceName in allNamespaceList:
                 userGuideName = guideModule.userGuideName
-                if not cmds.objExists(userGuideName+'_Grp'):
+                if not cmds.objExists(userGuideName+'_Static_Grp'):
                     modulesToBeRiggedList.append(guideModule)
     return modulesToBeRiggedList
 

--- a/dpAutoRigSystem/Modules/dpBaseClass.py
+++ b/dpAutoRigSystem/Modules/dpBaseClass.py
@@ -366,6 +366,15 @@ class StartClass(object):
                 self.userGuideName = prefix + self.userGuideName
             cmds.select(clear=True)
     
+
+    def hookSetup(self, *args):
+        """ Add message attributes to map hooked groups for the rigged module.
+        """
+        cmds.addAttr(self.toStaticHookGrp, longName="controlHookGrp", attributeType="message")
+        cmds.addAttr(self.toStaticHookGrp, longName="scalableHookGrp", attributeType="message")
+        cmds.connectAttr(self.toCtrlHookGrp+".message", self.toStaticHookGrp+".controlHookGrp", force=True)
+        cmds.connectAttr(self.toScalableHookGrp+".message", self.toStaticHookGrp+".scalableHookGrp", force=True)
+
     
     def integratingInfo(self, *args):
         """ This method just create this dictionary in order to build information of module integration.

--- a/dpAutoRigSystem/Modules/dpChain.py
+++ b/dpAutoRigSystem/Modules/dpChain.py
@@ -604,8 +604,8 @@ class Chain(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
 
                 # create a masterModuleGrp to be checked if this rig exists:
                 self.toCtrlHookGrp     = cmds.group(self.fkZeroGrpList[0], self.ikCtrlGrp, self.origFromList[0], self.worldRef, name=side+self.userGuideName+"_Control_Grp")
-                self.toScalableHookGrp = cmds.group(self.skinJointList[0], self.ikJointList[0], self.fkJointList[0], self.ikClusterGrp, name=side+self.userGuideName+"_Joint_Grp")
-                self.toStaticHookGrp   = cmds.group(self.toCtrlHookGrp, self.toScalableHookGrp, self.ikStaticDataGrp, ikMainLocGrp, name=side+self.userGuideName+"_Grp")
+                self.toScalableHookGrp = cmds.group(self.skinJointList[0], self.ikJointList[0], self.fkJointList[0], self.ikClusterGrp, name=side+self.userGuideName+"_Scalable_Grp")
+                self.toStaticHookGrp   = cmds.group(self.toCtrlHookGrp, self.toScalableHookGrp, self.ikStaticDataGrp, ikMainLocGrp, name=side+self.userGuideName+"_Static_Grp")
                 # create a locator in order to avoid delete static group
                 loc = cmds.spaceLocator(name=side+self.userGuideName+"_DO_NOT_DELETE_PLEASE_Loc")[0]
                 cmds.parent(loc, self.toStaticHookGrp, absolute=True)
@@ -622,6 +622,7 @@ class Chain(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                 # add module type counter value
                 cmds.addAttr(self.toStaticHookGrp, longName='dpAR_count', attributeType='long', keyable=False)
                 cmds.setAttr(self.toStaticHookGrp+'.dpAR_count', dpAR_count)
+                self.hookSetup()
                 if hideJoints:
                     cmds.setAttr(self.toScalableHookGrp+".visibility", 0)
                 # delete duplicated group for side (mirror):

--- a/dpAutoRigSystem/Modules/dpEye.py
+++ b/dpAutoRigSystem/Modules/dpEye.py
@@ -730,8 +730,8 @@ class Eye(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                     
                 # create a masterModuleGrp to be checked if this rig exists:
                 self.toCtrlHookGrp     = cmds.group(eyeZeroList[0], name=side+self.userGuideName+"_Control_Grp")
-                self.toScalableHookGrp = cmds.group(self.jxt, self.eyeScaleGrp, name=side+self.userGuideName+"_Joint_Grp")
-                self.toStaticHookGrp   = cmds.group(self.toCtrlHookGrp, self.toScalableHookGrp, name=side+self.userGuideName+"_Grp")
+                self.toScalableHookGrp = cmds.group(self.jxt, self.eyeScaleGrp, name=side+self.userGuideName+"_Scalable_Grp")
+                self.toStaticHookGrp   = cmds.group(self.toCtrlHookGrp, self.toScalableHookGrp, name=side+self.userGuideName+"_Static_Grp")
                 if s == 0:
                     cmds.parent(self.eyeGrp, self.toCtrlHookGrp)
                     cmds.parent(self.upLocGrp, self.toScalableHookGrp)
@@ -751,6 +751,7 @@ class Eye(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                 # add module type counter value
                 cmds.addAttr(self.toStaticHookGrp, longName='dpAR_count', attributeType='long', keyable=False)
                 cmds.setAttr(self.toStaticHookGrp+'.dpAR_count', dpAR_count)
+                self.hookSetup()
                 if hideJoints:
                     cmds.setAttr(self.toScalableHookGrp+".visibility", 0)
                 # delete duplicated group for side (mirror):

--- a/dpAutoRigSystem/Modules/dpFinger.py
+++ b/dpAutoRigSystem/Modules/dpFinger.py
@@ -511,16 +511,16 @@ class Finger(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                     # create a masterModuleGrp to be checked if this rig exists:
                     self.toCtrlHookGrp = cmds.group(self.ikCtrlZero, side+self.userGuideName+"_00_SDK_Zero_0_Grp", side+self.userGuideName+"_01_SDK_Zero_0_Grp", name=side+self.userGuideName+"_Control_Grp")
                     if self.nJoints == 2:
-                        self.toScalableHookGrp = cmds.group(self.skinJointList[0], ikBaseJoint, fkBaseJoint, ikHandleGrp, distBetweenList[2], distBetweenList[3], distBetweenList[4], name=side+self.userGuideName+"_Joint_Grp")
+                        self.toScalableHookGrp = cmds.group(self.skinJointList[0], ikBaseJoint, fkBaseJoint, ikHandleGrp, distBetweenList[2], distBetweenList[3], distBetweenList[4], name=side+self.userGuideName+"_Scalable_Grp")
                     else:
-                        self.toScalableHookGrp = cmds.group(self.skinJointList[0], ikHandleGrp, distBetweenList[2], distBetweenList[3], distBetweenList[4], name=side+self.userGuideName+"_Joint_Grp")
+                        self.toScalableHookGrp = cmds.group(self.skinJointList[0], ikHandleGrp, distBetweenList[2], distBetweenList[3], distBetweenList[4], name=side+self.userGuideName+"_Scalable_Grp")
                 else:
                     self.toCtrlHookGrp = cmds.group(side+self.userGuideName+"_00_SDK_Zero_0_Grp", side+self.userGuideName+"_01_SDK_Zero_0_Grp", name=side+self.userGuideName+"_Control_Grp")
-                    self.toScalableHookGrp = cmds.group(side+self.userGuideName+"_00_Jnt", name=side+self.userGuideName+"_Joint_Grp")
+                    self.toScalableHookGrp = cmds.group(side+self.userGuideName+"_00_Jnt", name=side+self.userGuideName+"_Scalable_Grp")
                 if self.addCorrective:
                     cmds.parent(self.correctiveCtrlsGrp, self.toCtrlHookGrp)
                 self.scalableGrpList.append(self.toScalableHookGrp)
-                self.toStaticHookGrp = cmds.group(self.toCtrlHookGrp, self.toScalableHookGrp, name=side+self.userGuideName+"_Grp")
+                self.toStaticHookGrp = cmds.group(self.toCtrlHookGrp, self.toScalableHookGrp, name=side+self.userGuideName+"_Static_Grp")
                 # add hook attributes to be read when rigging integrated modules:
                 dpUtils.addHook(objName=self.toCtrlHookGrp, hookType='ctrlHook')
                 dpUtils.addHook(objName=self.toScalableHookGrp, hookType='scalableHook')
@@ -532,6 +532,7 @@ class Finger(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                 # add module type counter value
                 cmds.addAttr(self.toStaticHookGrp, longName='dpAR_count', attributeType='long', keyable=False)
                 cmds.setAttr(self.toStaticHookGrp+'.dpAR_count', dpAR_count)
+                self.hookSetup()
                 # create a locator in order to avoid delete static group
                 loc = cmds.spaceLocator(name=side+self.userGuideName+"_DO_NOT_DELETE_PLEASE_Loc")[0]
                 cmds.parent(loc, self.toStaticHookGrp, absolute=True)

--- a/dpAutoRigSystem/Modules/dpFkLine.py
+++ b/dpAutoRigSystem/Modules/dpFkLine.py
@@ -254,8 +254,8 @@ class FkLine(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                         cmds.delete(cmds.parentConstraint(self.cvEndJoint, self.endJoint, maintainOffset=False))
                 # create a masterModuleGrp to be checked if this rig exists:
                 self.toCtrlHookGrp     = cmds.group(self.ctrlZeroGrp, name=side+self.userGuideName+"_Control_Grp")
-                self.toScalableHookGrp = cmds.group(self.skinJointList[0], name=side+self.userGuideName+"_Joint_Grp")
-                self.toStaticHookGrp   = cmds.group(self.toCtrlHookGrp, self.toScalableHookGrp, name=side+self.userGuideName+"_Grp")
+                self.toScalableHookGrp = cmds.group(self.skinJointList[0], name=side+self.userGuideName+"_Scalable_Grp")
+                self.toStaticHookGrp   = cmds.group(self.toCtrlHookGrp, self.toScalableHookGrp, name=side+self.userGuideName+"_Static_Grp")
                 # create a locator in order to avoid delete static group
                 loc = cmds.spaceLocator(name=side+self.userGuideName+"_DO_NOT_DELETE_PLEASE_Loc")[0]
                 cmds.parent(loc, self.toStaticHookGrp, absolute=True)
@@ -272,6 +272,7 @@ class FkLine(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                 # add module type counter value
                 cmds.addAttr(self.toStaticHookGrp, longName='dpAR_count', attributeType='long', keyable=False)
                 cmds.setAttr(self.toStaticHookGrp+'.dpAR_count', dpAR_count)
+                self.hookSetup()
                 if hideJoints:
                     cmds.setAttr(self.toScalableHookGrp+".visibility", 0)
                 # delete duplicated group for side (mirror):

--- a/dpAutoRigSystem/Modules/dpFoot.py
+++ b/dpAutoRigSystem/Modules/dpFoot.py
@@ -424,7 +424,7 @@ class Foot(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                 self.toCtrlHookGrp = cmds.group(self.footCtrlZeroList[0], name=side+self.userGuideName+"_Control_Grp")
                 self.revFootCtrlGrpFinalList.append(self.toCtrlHookGrp)
                 
-                self.toScalableHookGrp = cmds.createNode("transform", name=side+self.userGuideName+"_Joint_Grp")
+                self.toScalableHookGrp = cmds.createNode("transform", name=side+self.userGuideName+"_Scalable_Grp")
                 mWorldFoot = cmds.getAttr(self.footJnt+".worldMatrix")
                 cmds.xform(self.toScalableHookGrp, matrix=mWorldFoot, worldSpace=True)
                 cmds.parent(self.footJnt, self.toScalableHookGrp, absolute=True)
@@ -434,7 +434,7 @@ class Foot(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                 cmds.setAttr(self.footJnt+".jointOrientZ", 0)
                 self.aScalableGrp.append(self.toScalableHookGrp)
                 
-                self.toStaticHookGrp = cmds.group(self.toCtrlHookGrp, self.toScalableHookGrp, name=side+self.userGuideName+"_Grp")
+                self.toStaticHookGrp = cmds.group(self.toCtrlHookGrp, self.toScalableHookGrp, name=side+self.userGuideName+"_Static_Grp")
                 cmds.addAttr(self.toStaticHookGrp, longName="dpAR_name", dataType="string")
                 cmds.addAttr(self.toStaticHookGrp, longName="dpAR_type", dataType="string")
                 cmds.setAttr(self.toStaticHookGrp+".dpAR_name", self.userGuideName, type="string")
@@ -451,9 +451,9 @@ class Foot(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                 dpUtils.addHook(objName=self.toCtrlHookGrp, hookType='ctrlHook')
                 dpUtils.addHook(objName=self.toScalableHookGrp, hookType='scalableHook')
                 dpUtils.addHook(objName=self.toStaticHookGrp, hookType='staticHook')
+                self.hookSetup()
                 if hideJoints:
                     cmds.setAttr(self.toScalableHookGrp+".visibility", 0)
-
                 # delete duplicated group for side (mirror):
                 cmds.delete(side+self.userGuideName+'_'+self.mirrorGrp)
             # finalize this rig:

--- a/dpAutoRigSystem/Modules/dpHead.py
+++ b/dpAutoRigSystem/Modules/dpHead.py
@@ -808,8 +808,8 @@ class Head(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                 self.toCtrlHookGrp     = cmds.group(self.zeroNeckCtrlList[0], self.zeroCtrlList[2], self.zeroCtrlList[8], self.zeroCtrlList[9], name=side+self.userGuideName+"_Control_Grp")
                 if self.addCorrective:
                     cmds.parent(self.correctiveCtrlsGrp, self.toCtrlHookGrp)
-                self.toScalableHookGrp = cmds.group(self.neckJointList[0], name=side+self.userGuideName+"_Joint_Grp")
-                self.toStaticHookGrp   = cmds.group(self.toCtrlHookGrp, self.toScalableHookGrp, self.worldRef, name=side+self.userGuideName+"_Grp")
+                self.toScalableHookGrp = cmds.group(self.neckJointList[0], name=side+self.userGuideName+"_Scalable_Grp")
+                self.toStaticHookGrp   = cmds.group(self.toCtrlHookGrp, self.toScalableHookGrp, self.worldRef, name=side+self.userGuideName+"_Static_Grp")
                 cmds.addAttr(self.toStaticHookGrp, longName="dpAR_name", dataType="string")
                 cmds.addAttr(self.toStaticHookGrp, longName="dpAR_type", dataType="string")
                 cmds.setAttr(self.toStaticHookGrp+".dpAR_name", self.userGuideName, type="string")
@@ -821,10 +821,10 @@ class Head(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                 dpUtils.addHook(objName=self.toCtrlHookGrp, hookType='ctrlHook')
                 dpUtils.addHook(objName=self.toScalableHookGrp, hookType='scalableHook')
                 dpUtils.addHook(objName=self.toStaticHookGrp, hookType='staticHook')
-
+                self.hookSetup()
                 if hideJoints:
                     cmds.setAttr(self.toScalableHookGrp+".visibility", 0)
-                
+
                 # delete duplicated group for side (mirror):
                 cmds.delete(side+self.userGuideName+'_'+self.mirrorGrp)
             # finalize this rig:

--- a/dpAutoRigSystem/Modules/dpLimb.py
+++ b/dpAutoRigSystem/Modules/dpLimb.py
@@ -1171,17 +1171,17 @@ class Limb(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                     # (James) not implementing the forearm control if we use ribbons (yet)
                     if self.getHasBend() == True:
                         # do not use forearm control
-                        self.toCtrlHookGrp = cmds.group(self.zeroFkCtrlGrp, self.zeroCornerGrp, self.ikExtremCtrlZero, self.cornerOrientGrp, distBetGrp, self.origFromList[0], self.origFromList[1], self.ikFkBlendGrpToRevFoot, self.worldRef, self.masterCtrlRef, name=side + self.userGuideName + "_Control_Grp")
+                        self.toCtrlHookGrp = cmds.group(self.zeroFkCtrlGrp, self.zeroCornerGrp, self.ikExtremCtrlZero, self.cornerOrientGrp, distBetGrp, self.origFromList[0], self.origFromList[1], self.ikFkBlendGrpToRevFoot, self.worldRef, self.masterCtrlRef, name=side+self.userGuideName+"_Control_Grp")
                     else:
                         # use forearm control
-                        self.toCtrlHookGrp = cmds.group(self.zeroFkCtrlGrp, self.zeroCornerGrp, self.ikExtremCtrlZero, self.cornerOrientGrp, forearmZero, distBetGrp, self.origFromList[0], self.origFromList[1], self.ikFkBlendGrpToRevFoot, self.worldRef, self.masterCtrlRef, name=side + self.userGuideName + "_Control_Grp")
+                        self.toCtrlHookGrp = cmds.group(self.zeroFkCtrlGrp, self.zeroCornerGrp, self.ikExtremCtrlZero, self.cornerOrientGrp, forearmZero, distBetGrp, self.origFromList[0], self.origFromList[1], self.ikFkBlendGrpToRevFoot, self.worldRef, self.masterCtrlRef, name=side+self.userGuideName+"_Control_Grp")
                 else:
-                    self.toCtrlHookGrp = cmds.group(self.zeroFkCtrlGrp, self.zeroCornerGrp, self.ikExtremCtrlZero, self.cornerOrientGrp, distBetGrp, self.origFromList[0], self.origFromList[1], self.ikFkBlendGrpToRevFoot, self.worldRef, self.masterCtrlRef, name=side + self.userGuideName + "_Control_Grp")
-                self.toScalableHookGrp = cmds.group(name=side + self.userGuideName + "_Joint_Grp", empty=True)
+                    self.toCtrlHookGrp = cmds.group(self.zeroFkCtrlGrp, self.zeroCornerGrp, self.ikExtremCtrlZero, self.cornerOrientGrp, distBetGrp, self.origFromList[0], self.origFromList[1], self.ikFkBlendGrpToRevFoot, self.worldRef, self.masterCtrlRef, name=side+self.userGuideName+"_Control_Grp")
+                self.toScalableHookGrp = cmds.group(name=side+self.userGuideName+"_Scalable_Grp", empty=True)
                 cmds.parent(self.skinJointList[0], self.ikJointList[0], self.fkJointList[0], self.ikNSJointList[0], self.ikACJointList[1], self.toScalableHookGrp)
                 self.aScalableGrps.append(self.toScalableHookGrp)
-                cmds.parentConstraint(self.toCtrlHookGrp, self.toScalableHookGrp, maintainOffset=True, name=self.toScalableHookGrp + "_PaC")
-                self.toStaticHookGrp = cmds.group(self.toCtrlHookGrp, self.toScalableHookGrp, ikHandleGrp, ikHandleNotStretchGrp, ikHandleACGrp, name=side + self.userGuideName + "_Grp")
+                cmds.parentConstraint(self.toCtrlHookGrp, self.toScalableHookGrp, maintainOffset=True, name=self.toScalableHookGrp+"_PaC")
+                self.toStaticHookGrp = cmds.group(self.toCtrlHookGrp, self.toScalableHookGrp, ikHandleGrp, ikHandleNotStretchGrp, ikHandleACGrp, name=side+self.userGuideName+"_Static_Grp")
 
                 # clean-up before joint not used to autoClavicle:
                 cmds.delete(self.ikACJointList[0])
@@ -1667,6 +1667,7 @@ class Limb(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                 # add module type counter value
                 cmds.addAttr(self.toStaticHookGrp, longName='dpAR_count', attributeType='long', keyable=False)
                 cmds.setAttr(self.toStaticHookGrp + '.dpAR_count', dpAR_count)
+                self.hookSetup()
                 if hideJoints:
                     cmds.setAttr(self.toScalableHookGrp + ".visibility", 0)
                 # delete duplicated group for side (mirror):

--- a/dpAutoRigSystem/Modules/dpNose.py
+++ b/dpAutoRigSystem/Modules/dpNose.py
@@ -485,8 +485,8 @@ class Nose(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
 
                 # create a masterModuleGrp to be checked if this rig exists:
                 self.toCtrlHookGrp     = cmds.group(self.ctrlZeroGrp, name=side+self.userGuideName+"_Control_Grp")
-                self.toScalableHookGrp = cmds.group(self.skinJointList[0], name=side+self.userGuideName+"_Joint_Grp")
-                self.toStaticHookGrp   = cmds.group(self.toCtrlHookGrp, self.toScalableHookGrp, name=side+self.userGuideName+"_Grp")
+                self.toScalableHookGrp = cmds.group(self.skinJointList[0], name=side+self.userGuideName+"_Scalable_Grp")
+                self.toStaticHookGrp   = cmds.group(self.toCtrlHookGrp, self.toScalableHookGrp, name=side+self.userGuideName+"_Static_Grp")
                 # create a locator in order to avoid delete static group
                 loc = cmds.spaceLocator(name=side+self.userGuideName+"_DO_NOT_DELETE_PLEASE_Loc")[0]
                 cmds.parent(loc, self.toStaticHookGrp, absolute=True)
@@ -503,6 +503,7 @@ class Nose(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                 # add module type counter value
                 cmds.addAttr(self.toStaticHookGrp, longName='dpAR_count', attributeType='long', keyable=False)
                 cmds.setAttr(self.toStaticHookGrp+'.dpAR_count', dpAR_count)
+                self.hookSetup()
                 if hideJoints:
                     cmds.setAttr(self.toScalableHookGrp+".visibility", 0)
                 # delete duplicated group for side (mirror):

--- a/dpAutoRigSystem/Modules/dpSingle.py
+++ b/dpAutoRigSystem/Modules/dpSingle.py
@@ -284,11 +284,11 @@ class Single(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                     locScale = cmds.spaceLocator(name=side+self.userGuideName+"_Scalable_DO_NOT_DELETE_PLEASE_Loc")[0]
                     cmds.setAttr(locScale+".visibility", 0)
                     self.toScalableHookGrp = cmds.group(locScale, name=side+self.userGuideName+"_IndirectSkin_Grp")
-                    jxtGrp = cmds.group(side+self.userGuideName+"_Jxt", name=side+self.userGuideName+"_Joint_Grp")
-                    self.toStaticHookGrp   = cmds.group(jxtGrp, self.toScalableHookGrp, self.toCtrlHookGrp, name=side+self.userGuideName+"_Grp")
+                    jxtGrp = cmds.group(side+self.userGuideName+"_Jxt", name=side+self.userGuideName+"_Scalable_Grp")
+                    self.toStaticHookGrp   = cmds.group(jxtGrp, self.toScalableHookGrp, self.toCtrlHookGrp, name=side+self.userGuideName+"_Static_Grp")
                 else:
-                    self.toScalableHookGrp = cmds.group(side+self.userGuideName+"_Jnt", name=side+self.userGuideName+"_Joint_Grp")
-                    self.toStaticHookGrp   = cmds.group(self.toCtrlHookGrp, self.toScalableHookGrp, name=side+self.userGuideName+"_Grp")
+                    self.toScalableHookGrp = cmds.group(side+self.userGuideName+"_Jnt", name=side+self.userGuideName+"_Scalable_Grp")
+                    self.toStaticHookGrp   = cmds.group(self.toCtrlHookGrp, self.toScalableHookGrp, name=side+self.userGuideName+"_Static_Grp")
                 # create a locator in order to avoid delete static or scalable group
                 loc = cmds.spaceLocator(name=side+self.userGuideName+"_DO_NOT_DELETE_PLEASE_Loc")[0]
                 cmds.parent(loc, self.toStaticHookGrp, absolute=True)
@@ -307,6 +307,7 @@ class Single(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                 # add module type counter value
                 cmds.addAttr(self.toStaticHookGrp, longName='dpAR_count', attributeType='long', keyable=False)
                 cmds.setAttr(self.toStaticHookGrp+'.dpAR_count', dpAR_count)
+                self.hookSetup()
                 if hideJoints:
                     cmds.setAttr(self.toScalableHookGrp+".visibility", 0)
                 # delete duplicated group for side (mirror):

--- a/dpAutoRigSystem/Modules/dpSteering.py
+++ b/dpAutoRigSystem/Modules/dpSteering.py
@@ -187,8 +187,8 @@ class Steering(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                 
                 # create a masterModuleGrp to be checked if this rig exists:
                 self.toCtrlHookGrp     = cmds.group(zeroOutCtrlGrpList[1], name=side+self.userGuideName+"_Control_Grp")
-                self.toScalableHookGrp = cmds.group(side+self.userGuideName+"_1_Jnt", name=side+self.userGuideName+"_Joint_Grp")
-                self.toStaticHookGrp   = cmds.group(self.toCtrlHookGrp, self.toScalableHookGrp, name=side+self.userGuideName+"_Grp")
+                self.toScalableHookGrp = cmds.group(side+self.userGuideName+"_1_Jnt", name=side+self.userGuideName+"_Scalable_Grp")
+                self.toStaticHookGrp   = cmds.group(self.toCtrlHookGrp, self.toScalableHookGrp, name=side+self.userGuideName+"_Static_Grp")
                 # create a locator in order to avoid delete static group
                 loc = cmds.spaceLocator(name=side+self.userGuideName+"_DO_NOT_DELETE_PLEASE_Loc")[0]
                 cmds.parent(loc, self.toStaticHookGrp, absolute=True)
@@ -205,6 +205,7 @@ class Steering(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                 # add module type counter value
                 cmds.addAttr(self.toStaticHookGrp, longName='dpAR_count', attributeType='long', keyable=False)
                 cmds.setAttr(self.toStaticHookGrp+'.dpAR_count', dpAR_count)
+                self.hookSetup()
                 if hideJoints:
                     cmds.setAttr(self.toScalableHookGrp+".visibility", 0)
                 # delete duplicated group for side (mirror):

--- a/dpAutoRigSystem/Modules/dpSuspension.py
+++ b/dpAutoRigSystem/Modules/dpSuspension.py
@@ -222,8 +222,8 @@ class Suspension(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                 
                 # create a masterModuleGrp to be checked if this rig exists:
                 self.toCtrlHookGrp     = cmds.group(self.mainCtrlList, name=side+self.userGuideName+"_Control_Grp")
-                self.toScalableHookGrp = cmds.group(self.jointList, name=side+self.userGuideName+"_Joint_Grp")
-                self.toStaticHookGrp   = cmds.group(self.toCtrlHookGrp, self.toScalableHookGrp, self.locatorsGrp, name=side+self.userGuideName+"_Grp")
+                self.toScalableHookGrp = cmds.group(self.jointList, name=side+self.userGuideName+"_Scalable_Grp")
+                self.toStaticHookGrp   = cmds.group(self.toCtrlHookGrp, self.toScalableHookGrp, self.locatorsGrp, name=side+self.userGuideName+"_Static_Grp")
                 # add hook attributes to be read when rigging integrated modules:
                 dpUtils.addHook(objName=self.toCtrlHookGrp, hookType='ctrlHook')
                 dpUtils.addHook(objName=self.toScalableHookGrp, hookType='scalableHook')
@@ -236,6 +236,7 @@ class Suspension(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                 cmds.addAttr(self.toStaticHookGrp, longName='dpAR_count', attributeType='long', keyable=False)
                 cmds.setAttr(self.toStaticHookGrp+'.dpAR_count', dpAR_count)
                 self.ctrlHookGrpList.append(self.toCtrlHookGrp)
+                self.hookSetup()
                 if hideJoints:
                     cmds.setAttr(self.toScalableHookGrp+".visibility", 0)
                 # delete duplicated group for side (mirror):

--- a/dpAutoRigSystem/Modules/dpWheel.py
+++ b/dpAutoRigSystem/Modules/dpWheel.py
@@ -411,8 +411,8 @@ class Wheel(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                 
                 # create a masterModuleGrp to be checked if this rig exists:
                 self.toCtrlHookGrp     = cmds.group(zeroGrpList[2], name=side+self.userGuideName+"_Control_Grp")
-                self.toScalableHookGrp = cmds.group(self.centerJoint, self.mainJoint, defGrp, name=side+self.userGuideName+"_Joint_Grp")
-                self.toStaticHookGrp = cmds.group(self.toCtrlHookGrp, self.toScalableHookGrp, self.oldLoc, self.wheelAutoGrpLoc, self.geoHolder, name=side+self.userGuideName+"_Grp")
+                self.toScalableHookGrp = cmds.group(self.centerJoint, self.mainJoint, defGrp, name=side+self.userGuideName+"_Scalable_Grp")
+                self.toStaticHookGrp = cmds.group(self.toCtrlHookGrp, self.toScalableHookGrp, self.oldLoc, self.wheelAutoGrpLoc, self.geoHolder, name=side+self.userGuideName+"_Static_Grp")
                 # add hook attributes to be read when rigging integrated modules:
                 dpUtils.addHook(objName=self.toCtrlHookGrp, hookType='ctrlHook')
                 dpUtils.addHook(objName=self.toScalableHookGrp, hookType='scalableHook')
@@ -425,6 +425,7 @@ class Wheel(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                 cmds.addAttr(self.toStaticHookGrp, longName='dpAR_count', attributeType='long', keyable=False)
                 cmds.setAttr(self.toStaticHookGrp+'.dpAR_count', dpAR_count)
                 self.ctrlHookGrpList.append(self.toCtrlHookGrp)
+                self.hookSetup()
                 if hideJoints:
                     cmds.setAttr(self.toScalableHookGrp+".visibility", 0)
                 # delete duplicated group for side (mirror):

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -19,8 +19,8 @@
 
 
 # current version:
-DPAR_VERSION_PY3 = "4.01.19"
-DPAR_UPDATELOG = "N206 PinGuide locked attributes."
+DPAR_VERSION_PY3 = "4.01.20"
+DPAR_UPDATELOG = "N428 Group naming of module data.\nChanged to _Static_Grp and _Scalable_Grp\nto avoid naming conflict."
 
 
 
@@ -2240,10 +2240,10 @@ class DP_AutoRig_UI(object):
                             self.itemGuideName = sideName + self.prefix + self.itemGuideInstance
                         
                         # get hook groups info:
-                        self.itemRiggedGrp = self.itemGuideName + "_Grp"
+                        self.itemRiggedGrp = self.itemGuideName+"_Static_Grp"
                         self.staticHookGrp = self.itemRiggedGrp
-                        self.ctrlHookGrp = ""
-                        self.scalableHookGrp = ""
+                        self.ctrlHookGrp = cmds.listConnections(self.itemRiggedGrp+".controlHookGrp", destination=False, source=True)[0]
+                        self.scalableHookGrp = cmds.listConnections(self.itemRiggedGrp+".scalableHookGrp", destination=False, source=True)[0]
                         self.rootHookGrp = ""
                         riggedChildList = cmds.listRelatives(self.itemRiggedGrp, children=True, type='transform')
                         if riggedChildList:
@@ -2258,8 +2258,8 @@ class DP_AutoRig_UI(object):
                                     self.rootHookGrp = child
                         
                         # get guideModule hierarchy data:
-                        self.fatherGuide  = self.hookDic[guideModule.moduleGrp]['fatherGuide']
-                        self.parentNode   = self.hookDic[guideModule.moduleGrp]['parentNode']
+                        self.fatherGuide = self.hookDic[guideModule.moduleGrp]['fatherGuide']
+                        self.parentNode  = self.hookDic[guideModule.moduleGrp]['parentNode']
                         
                         # get father info:
                         if self.fatherGuide:


### PR DESCRIPTION
Changed the name for data groups for each module to be _Static_Grp and _Scalable_Grp. Also edited the staticGrp to have 2 new message attributes linked to the controlsGrp and scalableGrp.