### PR TITLE
N164 Display rotateOrder attribute

### DIFF
--- a/dpAutoRigSystem/Controls/dpBaseControlClass.py
+++ b/dpAutoRigSystem/Controls/dpBaseControlClass.py
@@ -97,6 +97,7 @@ class ControlStartClass:
         cvCurve = cmds.curve(name=cvName, point=cvPointList, degree=cvDegree, knot=cvKnot, periodic=cvPeriodic)
         self.addControlInfo(cvCurve, dpGuide=dpGuide)
         self.ctrls.renameShape([cvCurve])
+        self.ctrls.displayRotateOrderAttr([cvCurve])
         return cvCurve
     
     

--- a/dpAutoRigSystem/Modules/Library/dpControls.py
+++ b/dpAutoRigSystem/Modules/Library/dpControls.py
@@ -1267,3 +1267,12 @@ class ControlClass(object):
                     cmds.setAttr(ctrlName+".calibrate"+attr+axis, newValue)
             cmds.delete(dupTemp)
             cmds.select(ctrlName)
+
+
+    def displayRotateOrderAttr(self, ctrlList, *args):
+        """ Set display a non keyable rotateOrder attribute in the channelBox.
+        """
+        if ctrlList:
+            for ctrl in ctrlList:
+                if cmds.objExists(ctrl+".rotateOrder"):
+                    cmds.setAttr(ctrl+".rotateOrder", keyable=False, channelBox=True)

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -19,8 +19,8 @@
 
 
 # current version:
-DPAR_VERSION_PY3 = "4.01.33"
-DPAR_UPDATELOG = "N612 - Limb poleVector behavior."
+DPAR_VERSION_PY3 = "4.01.34"
+DPAR_UPDATELOG = "N164 - Display rotateOrder attribute."
 
 
 


### PR DESCRIPTION
Showing the controllers rotateOrder attribute as non keyable in the channelBox.