### PR TITLE
N638 TargetCleaner deleting issue fix

### DIFF
--- a/dpAutoRigSystem/Validator/CheckOut/dpTargetCleaner.py
+++ b/dpAutoRigSystem/Validator/CheckOut/dpTargetCleaner.py
@@ -11,7 +11,7 @@ TITLE = "v012_targetCleaner"
 DESCRIPTION = "v013_targetCleanerDesc"
 ICON = "/Icons/dp_targetCleaner.png"
 
-dpTargetCleaner_Version = 1.5
+dpTargetCleaner_Version = 1.6
 
 DPKEEPITATTR = "dpKeepIt"
 
@@ -144,8 +144,8 @@ class TargetCleaner(dpBaseValidatorClass.ValidatorStartClass):
         if grpList:
             for item in grpList:
                 nodeGrp = dpUtils.getNodeByMessage(item)
-            if nodeGrp:
-                nodeList = cmds.listRelatives(nodeGrp, allDescendents=True, children=True, type="transform", fullPath=False)
-                if nodeList:
-                    resultList.extend(nodeList)
+                if nodeGrp:
+                    nodeList = cmds.listRelatives(nodeGrp, allDescendents=True, children=True, type="transform", fullPath=False)
+                    if nodeList:
+                        resultList.extend(nodeList)
         return resultList

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -19,8 +19,8 @@
 
 
 # current version:
-DPAR_VERSION_PY3 = "4.02.06"
-DPAR_UPDATELOG = "N676 - Added ColorSet node cleaner\ncheckout validator."
+DPAR_VERSION_PY3 = "4.02.07"
+DPAR_UPDATELOG = "N638 - TargetCleaner deleting issue fixed."
 
 
 


### PR DESCRIPTION
Fixed the keepIt renderGrp issue. Now we don't touch tho the Render_Grp and its children.