### PR TITLE
N664 Overwrite archived published old version

### DIFF
--- a/dpAutoRigSystem/Pipeline/dpPackager.py
+++ b/dpAutoRigSystem/Pipeline/dpPackager.py
@@ -7,7 +7,7 @@ import shutil
 import os
 
 
-DPPACKAGER_VERSION = 1.2
+DPPACKAGER_VERSION = 1.3
 
 
 RIGPREVIEW = "Rigging Preview"
@@ -215,6 +215,7 @@ class Packager(object):
                     sceneList.append(entry.name)
         if sceneList:
             for item in sceneList:
+                self.removeExistingArchived(destinationFolder, item)
                 shutil.move(scenePath+"/"+item, destinationFolder)
 
     
@@ -236,4 +237,12 @@ class Packager(object):
         """
         for item in assetNameList:
             if not item == publishFilename:
+                self.removeExistingArchived(destinationFolder, item)
                 shutil.move(sourceFolder+"/"+item, destinationFolder)
+
+
+    def removeExistingArchived(self, filePath, fileName, *args):
+        """ Delete existing same achived version in dpOld if it exists to avoid naming conflict when copying.
+        """
+        if os.path.isfile(filePath+"/"+fileName):
+            os.remove(filePath+"/"+fileName)

--- a/dpAutoRigSystem/Pipeline/dpPipeliner.py
+++ b/dpAutoRigSystem/Pipeline/dpPipeliner.py
@@ -7,7 +7,7 @@ from functools import partial
 from ..Modules.Library import dpUtils
 
 
-DPPIPELINER_VERSION = 1.3
+DPPIPELINER_VERSION = 1.4
 
 PIPE_FOLDER = "_dpPipeline"
 
@@ -500,3 +500,4 @@ class Pipeliner(object):
                                 self.pipeData['dropboxPath'] = self.pipeData['dropInfoPath']+"/"+self.pipeData['s_dropbox']+"/"+self.pipeData['f_studio']+"/"+self.pipeData['f_project']
                                 self.makeDirIfNotExists(self.pipeData['dropboxPath'])
             # old 
+            self.makeDirIfNotExists(self.pipeData['publishPath']+"/"+self.pipeData['s_old'])

--- a/dpAutoRigSystem/Pipeline/dpPublisher.py
+++ b/dpAutoRigSystem/Pipeline/dpPublisher.py
@@ -11,7 +11,7 @@ reload(dpPipeliner)
 reload(dpPackager)
 
 
-DPPUBLISHER_VERSION = 1.2
+DPPUBLISHER_VERSION = 1.3
 
 
 class Publisher(object):
@@ -338,11 +338,6 @@ class Publisher(object):
                     cmds.file(rename=self.pipeliner.pipeData['publishPath']+"/"+publishFileName)
                     cmds.file(save=True, type=cmds.file(query=True, type=True)[0], prompt=False, force=True)
 
-                    # organize old published files
-                    if self.assetNameList:
-                        self.pipeliner.makeDirIfNotExists(self.pipeliner.pipeData['publishPath']+"/"+self.pipeliner.pipeData['s_old'])
-                        self.packager.toOld(self.pipeliner.pipeData['publishPath'], publishFileName, self.assetNameList, self.pipeliner.pipeData['publishPath']+"/"+self.pipeliner.pipeData['s_old'])
-
                     # packager
                     if self.pipeliner.pipeData['b_deliver']:
                         progressAmount += 1
@@ -358,6 +353,9 @@ class Publisher(object):
                         # hist
                         if self.pipeliner.pipeData['historyPath']:
                             self.packager.toHistory(self.pipeliner.pipeData['scenePath'], self.pipeliner.pipeData['shortName'], self.pipeliner.pipeData['historyPath'])
+                        # organize old published files
+                        if self.assetNameList:
+                            self.packager.toOld(self.pipeliner.pipeData['publishPath'], publishFileName, self.assetNameList, self.pipeliner.pipeData['publishPath']+"/"+self.pipeliner.pipeData['s_old'])
 
                     # publisher log window
                     self.successPublishedWindow(publishFileName)

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -19,8 +19,8 @@
 
 
 # current version:
-DPAR_VERSION_PY3 = "4.02.17"
-DPAR_UPDATELOG = "N561 - Added Import reference file\ncheckin validator."
+DPAR_VERSION_PY3 = "4.02.18"
+DPAR_UPDATELOG = "N664 - Overwrite archived old version\nwhen publishing a file and already there're\nduplicated files in the Rigging/Published/dpOld folder."
 
 
 


### PR DESCRIPTION
Just removing the existing file with same name to avoid overwrite conflicts when archiving existing published old files.