### PR TITLE
N679 Conform Maya2024 MatchMesh.

### DIFF
--- a/dpAutoRigSystem/Extras/dpMatchMesh.py
+++ b/dpAutoRigSystem/Extras/dpMatchMesh.py
@@ -86,7 +86,7 @@ class MatchMesh(object):
                 # selecting meshes
                 cmds.select([fromMesh, toMesh])
                 meshList = om.MSelectionList()
-                om.MGlobal_getActiveSelectionList(meshList)
+                om.MGlobal.getActiveSelectionList(meshList)
                 
                 # declaring from and to objects, dagPaths and vertice lists
                 fromObject = om.MObject()

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -19,8 +19,8 @@
 
 
 # current version:
-DPAR_VERSION_PY3 = "4.02.26"
-DPAR_UPDATELOG = "N672 - Discord integration.\nAlso included Terms and Conditions."
+DPAR_VERSION_PY3 = "4.02.27"
+DPAR_UPDATELOG = "N679	Conform Maya2024 to use MatchMesh."
 
 
 


### PR DESCRIPTION
Conform Maya2024 to use MatchMesh just changing an "underscore" for a "dot" in: om.MGlobal.getActiveSelectionList(meshList)