### PR TITLE
736 fix display layer validator

### DIFF
--- a/dpAutoRigSystem/Validator/CheckOut/dpDisplayLayers.py
+++ b/dpAutoRigSystem/Validator/CheckOut/dpDisplayLayers.py
@@ -9,7 +9,7 @@ TITLE = "v054_displayLayers"
 DESCRIPTION = "v055_displayLayersDesc"
 ICON = "/Icons/dp_displayLyr.png"
 
-DP_DISPLAYLAYERS_VERSION = 1.1
+DP_DISPLAYLAYERS_VERSION = 1.2
 
 
 class DisplayLayers(dpBaseValidatorClass.ValidatorStartClass):
@@ -69,7 +69,7 @@ class DisplayLayers(dpBaseValidatorClass.ValidatorStartClass):
                     layersConfiguration = [geoLyrVisibility, geoLyrHideOnPlayback, geolLyrDisplayType, ctrlLyrVisibility, ctrlLyrHideOnPlayback, ctrlLyrDisplayType]
                     # Check layers configuration
                     if layersConfiguration == layersConfigurationCheckList:
-                        itemsInGeoLayerList = cmds.editDisplayLayerMembers(self.geoLayerName, query=True)
+                        itemsInGeoLayerList = cmds.editDisplayLayerMembers(self.geoLayerName, fullNames=True, query=True)
                         itemsInCtrlLayerList = cmds.editDisplayLayerMembers(self.ctrlLayerName, query=True)
                         # Check layers members
                         if itemsInGeoLayerList and itemsInCtrlLayerList:
@@ -159,16 +159,17 @@ class DisplayLayers(dpBaseValidatorClass.ValidatorStartClass):
         renderGrp = dpUtils.getNodeByMessage("renderGrp")
         proxyGrp = dpUtils.getNodeByMessage("proxyGrp")
         if renderGrp and proxyGrp:
-            renderGrpShapesList = cmds.listRelatives(renderGrp, allDescendents=True, type="mesh") or []
-            proxyGrpShapesList = cmds.listRelatives(proxyGrp, allDescendents=True, type="mesh") or []
+            renderGrpShapesList = cmds.listRelatives(renderGrp, allDescendents=True, fullPath=True, type="mesh") or []
+            proxyGrpShapesList = cmds.listRelatives(proxyGrp, allDescendents=True, fullPath=True, type="mesh") or []
             allShapesList = list(set(renderGrpShapesList + proxyGrpShapesList))
             allGeoList = []
             if allShapesList:
                 for shape in allShapesList:
                     if not "Orig" in shape:
                         try:
-                            transform = cmds.listRelatives(shape, parent=True)[0]
+                            transform = cmds.listRelatives(shape, fullPath=True, parent=True)[0]
                             # Get the transform only
+                            print(transform)
                             allGeoList.append(transform)
                         except:
                             pass

--- a/dpAutoRigSystem/Validator/CheckOut/dpDisplayLayers.py
+++ b/dpAutoRigSystem/Validator/CheckOut/dpDisplayLayers.py
@@ -166,13 +166,10 @@ class DisplayLayers(dpBaseValidatorClass.ValidatorStartClass):
             if allShapesList:
                 for shape in allShapesList:
                     if not "Orig" in shape:
-                        try:
-                            transform = cmds.listRelatives(shape, fullPath=True, parent=True)[0]
+                        transformList = cmds.listRelatives(shape, fullPath=True, parent=True)
+                        if transformList:
                             # Get the transform only
-                            print(transform)
-                            allGeoList.append(transform)
-                        except:
-                            pass
+                            allGeoList.append(transformList[0])
             return allGeoList
 
 

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -18,8 +18,8 @@
 ###################################################################
 
 
-DPAR_VERSION_PY3 = "4.03.18"
-DPAR_UPDATELOG = "N492 - Bike steering wheel pivot."
+DPAR_VERSION_PY3 = "4.03.19"
+DPAR_UPDATELOG = "N736 - Fixed display layer validator\n when there's duplicated name in the scene."
 
 
 


### PR DESCRIPTION
Fix display layer validator when there's duplicated name in the scene. Using fullName and fullPath for the functions: listRelatives and editDisplayLayerMembers.
Last commit cleaning print and try/except. Thank you.