### PR TITLE
N318 CopySkin existing method code duplicated multi

### DIFF
--- a/dpAutoRigSystem/Extras/dpCopySkin.py
+++ b/dpAutoRigSystem/Extras/dpCopySkin.py
@@ -55,6 +55,7 @@ class CopySkin(object):
                     if deleteIt:
                         cmds.delete(deformerNode)
                     result = True
+                    break
         return result
 
 
@@ -101,3 +102,7 @@ class CopySkin(object):
         cmds.copySkinWeights(noMirror=True, surfaceAssociation="closestPoint", influenceAssociation=["label", "oneToOne", "closestJoint"])
         # log result
         mel.eval("print \""+self.dpUIinst.lang['i083_copiedSkin']+" "+sourceItem+" "+destinationItem+"\"; ")
+
+
+# TODO
+# deformerOrder

--- a/dpAutoRigSystem/Extras/dpCopySkin.py
+++ b/dpAutoRigSystem/Extras/dpCopySkin.py
@@ -39,7 +39,7 @@ class CopySkin(object):
                     if skinInfList:
                         skinMethodToUse = cmds.skinCluster(sourceItem, query=True, skinMethod=True)
                         # call copySkin function
-                        self.dpCopySkin(sourceItem, destinationList, skinInfList, skinMethodToUse)
+                        self.dpCopySkin([sourceItem], destinationList, skinInfList, skinMethodToUse)
                 else:
                     mel.eval("warning \""+self.dpUIinst.lang['e007_notSkinFound']+"\";")
             else:
@@ -62,20 +62,25 @@ class CopySkin(object):
         return result
 
 
-    def dpCopySkin(self, sourceItem, destinationList, skinInfList, skinMethodToUse=0, *args):
+    def dpCopySkin(self, sourceList, destinationList, skinInfList=None, skinMethodToUse=0, oneSource=True, *args):
         """ Do the copy skin from sourceItem to destinationList using the skinInfList.
         """
-        for item in destinationList:
-            # get correct naming
-            skinClusterName = dpUtils.extractSuffix(item)
-            if "|" in skinClusterName:
-                skinClusterName = skinClusterName[skinClusterName.rfind("|")+1:]
-            self.checkExistingSkinClusterNode(item, True)
-            # create skinCluster node
-            cmds.skinCluster(skinInfList, item, name=skinClusterName+"_SC", toSelectedBones=True, maximumInfluences=3, skinMethod=skinMethodToUse)
-            cmds.select(sourceItem)
-            cmds.select(item, toggle=True)
-            # copy skin weights from sourceItem to item node
-            cmds.copySkinWeights(noMirror=True, surfaceAssociation="closestPoint", influenceAssociation=["label", "oneToOne", "closestJoint"])
-            # log result
-            mel.eval("print \""+self.dpUIinst.lang['i083_copiedSkin']+" "+sourceItem+" "+item+"\";")
+        for sourceItem in sourceList:
+            for item in destinationList:
+                # get correct naming
+                skinClusterName = dpUtils.extractSuffix(item)
+                if "|" in skinClusterName:
+                    skinClusterName = skinClusterName[skinClusterName.rfind("|")+1:]
+                self.checkExistingSkinClusterNode(item, True)
+                if not skinInfList:
+                    skinInfList = cmds.skinCluster(sourceItem, query=True, influence=True)
+                # create skinCluster node
+                cmds.skinCluster(skinInfList, item, name=skinClusterName+"_SC", toSelectedBones=True, maximumInfluences=3, skinMethod=skinMethodToUse)
+                cmds.select(sourceItem)
+                cmds.select(item, toggle=True)
+                # copy skin weights from sourceItem to item node
+                cmds.copySkinWeights(noMirror=True, surfaceAssociation="closestPoint", influenceAssociation=["label", "oneToOne", "closestJoint"])
+                # log result
+                mel.eval("print \""+self.dpUIinst.lang['i083_copiedSkin']+" "+sourceItem+" "+item+"\"; ")
+            if oneSource:
+                return

--- a/dpAutoRigSystem/Extras/dpCopySkin.py
+++ b/dpAutoRigSystem/Extras/dpCopySkin.py
@@ -9,7 +9,7 @@ TITLE = "m097_copySkin"
 DESCRIPTION = "m098_copySkinDesc"
 ICON = "/Icons/dp_copySkin.png"
 
-DP_COPYSKIN_VERSION = 1.4
+DP_COPYSKIN_VERSION = 1.5
 
 
 class CopySkin(object):
@@ -71,6 +71,16 @@ class CopySkin(object):
         return False
     
     
+    def deleteExistingSkinClusterNode(self, item, *args):
+        """ Delete existing skinCluster node if there's one
+        """
+        inputDeformerList = cmds.findDeformers(item)
+        if inputDeformerList:
+            for deformerNode in inputDeformerList:
+                if cmds.objectType(deformerNode) == "skinCluster":
+                    cmds.delete(deformerNode)
+
+
     def dpCopySkin(self, sourceItem, destinationList, skinInfList, *args):
         """ Do the copy skin from sourceItem to destinationList using the skinInfList.
         """
@@ -79,6 +89,7 @@ class CopySkin(object):
             skinClusterName = dpUtils.extractSuffix(item)
             if "|" in skinClusterName:
                 skinClusterName = skinClusterName[skinClusterName.rfind("|")+1:]
+            self.deleteExistingSkinClusterNode(item)
             # create skinCluster node
             cmds.skinCluster(skinInfList, item, name=skinClusterName+"_SC", toSelectedBones=True, maximumInfluences=3, skinMethod=0)
             cmds.select(sourceItem)

--- a/dpAutoRigSystem/Extras/dpCopySkin.py
+++ b/dpAutoRigSystem/Extras/dpCopySkin.py
@@ -13,11 +13,12 @@ DP_COPYSKIN_VERSION = 1.5
 
 
 class CopySkin(object):
-    def __init__(self, dpUIinst, *args):
+    def __init__(self, dpUIinst, ui=True, *args):
         # redeclaring variables
         self.dpUIinst = dpUIinst
         # call main function
-        self.dpMain(self)
+        if ui:
+            self.dpMain(self)
     
     
     def dpMain(self, *args):
@@ -32,14 +33,9 @@ class CopySkin(object):
             shapeList = cmds.listRelatives(sourceItem, shapes=True, fullPath=True)
             if shapeList:
                 # check if there's a skinCluster node connected to the first selected item
-                checkSkin = self.checkExistingSkinClusterNode(shapeList)
-                if checkSkin == True:
-                    # get joints influence from skinCluster
-                    skinInfList = cmds.skinCluster(sourceItem, query=True, influence=True)
-                    if skinInfList:
-                        skinMethodToUse = cmds.skinCluster(sourceItem, query=True, skinMethod=True)
-                        # call copySkin function
-                        self.dpCopySkin([sourceItem], destinationList, skinInfList, skinMethodToUse)
+                if self.checkExistingSkinClusterNode(shapeList):
+                    # call copySkin function
+                    self.dpSerializeCopySkin([sourceItem], destinationList)
                 else:
                     mel.eval("warning \""+self.dpUIinst.lang['e007_notSkinFound']+"\";")
             else:
@@ -47,7 +43,7 @@ class CopySkin(object):
         else:
             mel.eval("warning \""+self.dpUIinst.lang['e005_selectOneObj']+"\";")
 
-    
+
     def checkExistingSkinClusterNode(self, item, deleteIt=False, *args):
         """ Delete existing skinCluster node if there's one
         """
@@ -62,25 +58,46 @@ class CopySkin(object):
         return result
 
 
-    def dpCopySkin(self, sourceList, destinationList, skinInfList=None, skinMethodToUse=0, oneSource=True, *args):
-        """ Do the copy skin from sourceItem to destinationList using the skinInfList.
+    def dpSerializeCopySkin(self, sourceList, destinationList, oneSource=True, *args):
+        """ Serialize the copy skinning for one source or not.
         """
+        ranList = []
         for sourceItem in sourceList:
-            for item in destinationList:
-                # get correct naming
-                skinClusterName = dpUtils.extractSuffix(item)
-                if "|" in skinClusterName:
-                    skinClusterName = skinClusterName[skinClusterName.rfind("|")+1:]
-                self.checkExistingSkinClusterNode(item, True)
-                if not skinInfList:
-                    skinInfList = cmds.skinCluster(sourceItem, query=True, influence=True)
-                # create skinCluster node
-                cmds.skinCluster(skinInfList, item, name=skinClusterName+"_SC", toSelectedBones=True, maximumInfluences=3, skinMethod=skinMethodToUse)
-                cmds.select(sourceItem)
-                cmds.select(item, toggle=True)
-                # copy skin weights from sourceItem to item node
-                cmds.copySkinWeights(noMirror=True, surfaceAssociation="closestPoint", influenceAssociation=["label", "oneToOne", "closestJoint"])
-                # log result
-                mel.eval("print \""+self.dpUIinst.lang['i083_copiedSkin']+" "+sourceItem+" "+item+"\"; ")
             if oneSource:
+                for item in destinationList:
+                    self.dpCopySkin(sourceItem, item)
                 return
+            else:
+                if not sourceItem in ranList:
+                    for item in reversed(destinationList): #to avoid find the same item in the same given list
+                        if sourceItem[sourceItem.rfind("|")+1:] == item[item.rfind("|")+1:]:
+                            if self.checkExistingSkinClusterNode(sourceItem):
+                                self.dpCopySkin(sourceItem, item)
+                            else:
+                                self.dpCopySkin(item, sourceItem)
+                            # To avoid repeat the same item in the same given list
+                            ranList.append(sourceItem)
+                            ranList.append(item)
+                            break
+
+
+    def dpCopySkin(self, sourceItem, destinationItem, *args):
+        """ Copty the skin from sourceItem to destinationItem.
+            It will get skinInfList and skinMethod by source.
+        """
+        # get correct naming
+        skinClusterName = dpUtils.extractSuffix(destinationItem)
+        if "|" in skinClusterName:
+            skinClusterName = skinClusterName[skinClusterName.rfind("|")+1:]
+        # clean-up current destination skinCluster
+        self.checkExistingSkinClusterNode(destinationItem, True)
+        skinInfList = cmds.skinCluster(sourceItem, query=True, influence=True)
+        skinMethodToUse = cmds.skinCluster(sourceItem, query=True, skinMethod=True)
+        # create skinCluster node
+        cmds.skinCluster(skinInfList, destinationItem, name=skinClusterName+"_SC", toSelectedBones=True, maximumInfluences=3, skinMethod=skinMethodToUse)
+        cmds.select(sourceItem)
+        cmds.select(destinationItem, toggle=True)
+        # copy skin weights from sourceItem to item node
+        cmds.copySkinWeights(noMirror=True, surfaceAssociation="closestPoint", influenceAssociation=["label", "oneToOne", "closestJoint"])
+        # log result
+        mel.eval("print \""+self.dpUIinst.lang['i083_copiedSkin']+" "+sourceItem+" "+destinationItem+"\"; ")

--- a/dpAutoRigSystem/Extras/dpCopySkin.py
+++ b/dpAutoRigSystem/Extras/dpCopySkin.py
@@ -74,12 +74,12 @@ class CopySkin(object):
                         if sourceItem[sourceItem.rfind("|")+1:] == item[item.rfind("|")+1:]:
                             if self.checkExistingSkinClusterNode(sourceItem):
                                 self.dpCopySkin(sourceItem, item)
-                            else:
+                            elif self.checkExistingSkinClusterNode(item):
                                 self.dpCopySkin(item, sourceItem)
                             # To avoid repeat the same item in the same given list
-                            ranList.append(sourceItem)
                             ranList.append(item)
                             break
+                    ranList.append(sourceItem)
 
 
     def dpCopySkin(self, sourceItem, destinationItem, *args):

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -19,7 +19,7 @@
 
 
 DPAR_VERSION_PY3 = "4.03.21"
-DPAR_UPDATELOG = "N318 - Copy skin tool to existing skinCluster.\nN383 - Check skinCluster method to copy.\nN650 - Transfer skinning by code.\nN737 - Copy skin of duplicated name."
+DPAR_UPDATELOG = "N318 - Copy skin tool to existing skinCluster.\nN383 - Check skinCluster method to copy.\nN650 - Transfer skinning by code.\nN669 - Conform Maya2024 multiplies skinCluster.\nN737 - Copy skin of duplicated name."
 
 
 

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -18,8 +18,8 @@
 ###################################################################
 
 
-DPAR_VERSION_PY3 = "4.03.18"
-DPAR_UPDATELOG = "N492 - Bike steering wheel pivot."
+DPAR_VERSION_PY3 = "4.03.21"
+DPAR_UPDATELOG = "N318 - Copy skin tool to existing skinCluster.\nN383 - Check skinCluster method to copy.\nN650 - Transfer skinning by code.\nN737 - Copy skin of duplicated name."
 
 
 


### PR DESCRIPTION
Changed the CopySkin to accept Maya2024 multiple skinClusters, copy the skinning to existing skinCluster mesh, transfering the method, working with duplicated name and ready to run by code.