### PR TITLE
N738 FkLine back to zero segment error fixed

### DIFF
--- a/dpAutoRigSystem/Modules/dpFkLine.py
+++ b/dpAutoRigSystem/Modules/dpFkLine.py
@@ -10,7 +10,7 @@ TITLE = "m001_fkLine"
 DESCRIPTION = "m002_fkLineDesc"
 ICON = "/Icons/dp_fkLine.png"
 
-DP_FKLINE_VERSION = 2.1
+DP_FKLINE_VERSION = 2.2
 
 
 class FkLine(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
@@ -155,6 +155,9 @@ class FkLine(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
         # limit range
         if self.nMainCtrlAttr >= self.currentNJoints:
             self.nMainCtrlAttr = self.currentNJoints - 1
+            if self.nMainCtrlAttr == 0:
+                self.nMainCtrlAttr = 1
+                cmds.checkBox(self.mainCtrlsCB, edit=True, editable=False)
             cmds.intField(self.nMainCtrlIF, edit=True, value=self.nMainCtrlAttr)
         cmds.setAttr(self.moduleGrp+".nMain", self.nMainCtrlAttr)
 

--- a/dpAutoRigSystem/Modules/dpLayoutClass.py
+++ b/dpAutoRigSystem/Modules/dpLayoutClass.py
@@ -346,8 +346,9 @@ class LayoutClass(object):
                                 self.mainCtrlsCB = cmds.checkBox(label=self.dpUIinst.lang['m227_mainCtrls'], value=hasMain, enable=True, changeCommand=self.setAddMainCtrls, parent=self.mainCtrlColumn)
                                 self.nMainCtrlIF = cmds.intField(value=nMainCtrlAttr, minValue=1, changeCommand=partial(self.changeMainCtrlsNumber, 0), editable=hasMain, parent=self.mainCtrlColumn)
                             else:
-                                self.mainCtrlsCB = cmds.checkBox(label=self.dpUIinst.lang['m227_mainCtrls'], value=False, enable=False, changeCommand=self.setAddMainCtrls, parent=self.mainCtrlColumn)
+                                self.mainCtrlsCB = cmds.checkBox(label=self.dpUIinst.lang['m227_mainCtrls'], value=False, enable=True, changeCommand=self.setAddMainCtrls, parent=self.mainCtrlColumn)
                                 self.nMainCtrlIF = cmds.intField(value=nMainCtrlAttr, minValue=1, changeCommand=partial(self.changeMainCtrlsNumber, 0), editable=False, parent=self.mainCtrlColumn)
+                                cmds.setAttr(self.moduleGrp+".mainControls", 0)
 
             except:
                 pass

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -18,8 +18,8 @@
 ###################################################################
 
 
-DPAR_VERSION_PY3 = "4.03.24"
-DPAR_UPDATELOG = "N739 Added Unused nodes cleaner\nas a new check-out validator."
+DPAR_VERSION_PY3 = "4.03.25"
+DPAR_UPDATELOG = "N738 - FkLine back to 1 segment error fixed."
 
 
 


### PR DESCRIPTION
Just fixed the segment number change to zero error with a set module attribute to zero in the guide base node.