### PR TITLE
N750 Delete locked unknown nodes

### DIFF
--- a/dpAutoRigSystem/Validator/CheckOut/dpUnknownNodesCleaner.py
+++ b/dpAutoRigSystem/Validator/CheckOut/dpUnknownNodesCleaner.py
@@ -8,7 +8,7 @@ TITLE = "v058_unknownNodesCleaner"
 DESCRIPTION = "v059_unknownNodesCleanerDesc"
 ICON = "/Icons/dp_unknownNodesCleaner.png"
 
-DP_UNKNOWNNODESCLEANER_VERSION = 1.1
+DP_UNKNOWNNODESCLEANER_VERSION = 1.2
 
 
 class UnknownNodesCleaner(dpBaseValidatorClass.ValidatorStartClass):
@@ -57,6 +57,7 @@ class UnknownNodesCleaner(dpBaseValidatorClass.ValidatorStartClass):
                 else: #fix
                     try:
                         if cmds.objExists(item):
+                            cmds.lockNode(item, lock=False)
                             cmds.delete(item)
                         self.resultOkList.append(True)
                         self.messageList.append(self.dpUIinst.lang['v004_fixed']+": "+item)

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -18,8 +18,8 @@
 ###################################################################
 
 
-DPAR_VERSION_PY3 = "4.03.29"
-DPAR_UPDATELOG = "N754 Limb constraints fixes."
+DPAR_VERSION_PY3 = "4.03.30"
+DPAR_UPDATELOG = "N750 Delete locked unknown nodes."
 
 
 


### PR DESCRIPTION
Just fixed an error in the Unknown node cleaner checkout validator to avoid stop working if the node is locked.