### PR TITLE
N502 Disable OLD dpControl attr

### DIFF
--- a/dpAutoRigSystem/Modules/Library/jcRibbon.py
+++ b/dpAutoRigSystem/Modules/Library/jcRibbon.py
@@ -513,6 +513,7 @@ class RibbonClass(object):
         cmds.parent(aux_Jnt[0], mid_Loc[0])
         #create a nurbs control in order to be used in the ribbon offset
         mid_Ctrl = self.ctrls.cvControl("Circle", name+'_MidCtrl', r=self.ctrlRadius, d=self.curveDegree, rot=(0, 90, 0))
+        dpUtils.removeUserDefinedAttr(mid_Ctrl)
         midCtrl = mid_Ctrl
         mid_Ctrl = cmds.group(n=mid_Ctrl+'_Grp', em=True)
         cmds.delete(cmds.parentConstraint(midCtrl, mid_Ctrl, mo=0))

--- a/dpAutoRigSystem/Modules/dpSingle.py
+++ b/dpAutoRigSystem/Modules/dpSingle.py
@@ -10,7 +10,7 @@ TITLE = "m073_single"
 DESCRIPTION = "m074_singleDesc"
 ICON = "/Icons/dp_single.png"
 
-DP_SINGLE_VERSION = 2.0
+DP_SINGLE_VERSION = 2.1
 
 
 class Single(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
@@ -223,6 +223,7 @@ class Single(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                     if self.getHasHolder():
                         cmds.delete(self.singleCtrl+"0Shape", shape=True)
                         self.singleCtrl = cmds.rename(self.singleCtrl, self.singleCtrl+"_"+self.dpUIinst.lang['c046_holder']+"_Grp")
+                        dpUtils.removeUserDefinedAttr(self.singleCtrl)
                         self.ctrls.setLockHide([self.singleCtrl], ['tx', 'ty', 'tz', 'rx', 'ry', 'rz', 'sx', 'sy', 'sz', 'ro'])
                         self.jnt = cmds.rename(self.jnt, self.jnt.replace("_Jnt", "_"+self.dpUIinst.lang['c046_holder']+"_Jis"))
                         self.ctrls.setLockHide([self.jnt], ['tx', 'ty', 'tz', 'rx', 'ry', 'rz', 'sx', 'sy', 'sz', 'ro'], True, True)

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -18,8 +18,8 @@
 ###################################################################
 
 
-DPAR_VERSION_PY3 = "4.03.22"
-DPAR_UPDATELOG = "N337 CopySkin from Extra to Skinning tab.\nAdded options for surface association and\ncopy from one source or multiply itens with same name."
+DPAR_VERSION_PY3 = "4.03.25"
+DPAR_UPDATELOG = "N502 Disable old dpControl attributes.\nCleaned for Single Holders and Ribbon MidCtrls."
 
 
 


### PR DESCRIPTION
Removed userDefined attributes for Single Holder and Ribbon MidCtrl controllers.