### PR TITLE
773 dprivet morph conditional maya version

### DIFF
--- a/dpAutoRigSystem/Extras/dpRivet.py
+++ b/dpAutoRigSystem/Extras/dpRivet.py
@@ -106,13 +106,10 @@ class Rivet(object):
         self.faceToRivetCB = cmds.checkBox('faceToRivetCB', label=self.dpUIinst.lang["m226_createFaceToRivet"], height=20, value=True, changeCommand=self.dpChangeDeformer, parent=faceToRivetLayout)
         deformerLayout = cmds.columnLayout('deformerLayout', columnOffset=("left", 20), parent=faceToRivetLayout)
         self.deformerCollection = cmds.radioCollection('deformerCollection', parent=deformerLayout)
-        if self.mayaVersionRequired == True:
-            self.morphDeformerRB = cmds.radioButton(label=self.dpUIinst.lang["m232_morphDeformer"], annotation=self.morphDeformer, collection=self.deformerCollection)
-            self.wrapDeformerRB = cmds.radioButton(label=self.dpUIinst.lang["m233_wrapDeformer"], annotation=self.wrapDeformer, collection=self.deformerCollection)
-            cmds.radioCollection(self.deformerCollection, edit=True, select=self.morphDeformerRB)
-        if self.mayaVersionRequired == False:
-            self.morphDeformerRB = cmds.radioButton(label=self.dpUIinst.lang["m232_morphDeformer"], annotation=self.morphDeformer, enable=False, collection=self.deformerCollection)
-            self.wrapDeformerRB = cmds.radioButton(label=self.dpUIinst.lang["m233_wrapDeformer"], annotation=self.wrapDeformer,  enable=False, collection=self.deformerCollection)
+        self.morphDeformerRB = cmds.radioButton(label=self.dpUIinst.lang["m232_morphDeformer"], annotation=self.morphDeformer, enable=self.mayaVersionRequired, collection=self.deformerCollection)
+        self.wrapDeformerRB = cmds.radioButton(label=self.dpUIinst.lang["m233_wrapDeformer"], annotation=self.wrapDeformer, enable=self.mayaVersionRequired, collection=self.deformerCollection)
+        cmds.radioCollection(self.deformerCollection, edit=True, select=self.morphDeformerRB)
+        if not self.mayaVersionRequired:
             cmds.radioCollection(self.deformerCollection, edit=True, select=self.wrapDeformerRB)
         cmds.separator(style='none', height=15, parent=rivetLayout)
         createLayout = cmds.columnLayout('createLayout', columnOffset=("left", 10), parent=rivetLayout)
@@ -269,12 +266,10 @@ class Rivet(object):
 
 
     def dpChangeDeformer(self, value, *args):
-        if self.mayaVersionRequired == True:
-            cmds.radioButton(self.morphDeformerRB, edit=True, enable=value)
-            cmds.radioButton(self.wrapDeformerRB, edit=True, enable=value)
-        else:
-            cmds.radioButton(self.morphDeformerRB, edit=True, enable=False)
-            cmds.radioButton(self.wrapDeformerRB, edit=True, enable=False)
+        if not self.mayaVersionRequired:
+            value = False
+        cmds.radioButton(self.morphDeformerRB, edit=True, enable=value)
+        cmds.radioButton(self.wrapDeformerRB, edit=True, enable=value)
 
 
     def dpInvertAttrTranformation(self, nodeName, invT=True, invR=False, *args):
@@ -741,7 +736,5 @@ class Rivet(object):
         mayaVersion = cmds.about(installedVersion=True)
         installedVersion = float(mayaVersion.split(" ")[-1])
         minimalVersion = float(self.mayaMinimalVersion)
-        if installedVersion < minimalVersion:
-            return False
-        else:
+        if installedVersion > minimalVersion:
             return True

--- a/dpAutoRigSystem/Extras/dpRivet.py
+++ b/dpAutoRigSystem/Extras/dpRivet.py
@@ -733,8 +733,13 @@ class Rivet(object):
                 
 
     def checkMayaVersion(self, *args):
+        """ Get Maya's version installed to compare with the minimalVersionRequired (2022.3)
+            If the installed version is above the minimal it returns True, otherwise False
+        """ 
         mayaVersion = cmds.about(installedVersion=True)
         installedVersion = float(mayaVersion.split(" ")[-1])
         minimalVersion = float(self.mayaMinimalVersion)
         if installedVersion > minimalVersion:
             return True
+        else:
+            return False

--- a/dpAutoRigSystem/Extras/dpRivet.py
+++ b/dpAutoRigSystem/Extras/dpRivet.py
@@ -48,6 +48,7 @@ class Rivet(object):
         self.selectedUVSet = None
         self.morphDeformer = MORPH
         self.wrapDeformer = WRAP
+        self.mayaMinimalVersion = 2022.3
         self.mayaVersionRequired = self.checkMayaVersion()
         # call main function
         if ui:
@@ -739,7 +740,7 @@ class Rivet(object):
     def checkMayaVersion(self, *args):
         mayaVersion = cmds.about(installedVersion=True)
         installedVersion = float(mayaVersion.split(" ")[-1])
-        minimalVersion = float(2022.3)
+        minimalVersion = float(self.mayaMinimalVersion)
         if installedVersion < minimalVersion:
             return False
         else:

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -18,8 +18,8 @@
 ###################################################################
 
 
-DPAR_VERSION_PY3 = "4.03.43"
-DPAR_UPDATELOG = "N780 OriginedFrom fix to tweakers."
+DPAR_VERSION_PY3 = "4.03.45"
+DPAR_UPDATELOG = "N773 - Added conditional on dpRivet FaceToRivet to check \nMaya's version when using morphDeformer to avoid geometry missplacing. \nMinimal Maya's version: 2022.3."
 
 
 


### PR DESCRIPTION
Added conditional on dpRivet FaceToRivet to check Maya's version when using morphDeformer to avoid geometry missplacing. Minimal Maya's version: 2022.3. Thank you for the improvements, Danilo.