### PR TITLE
N771 ColorSet cleanup validator fix

### DIFF
--- a/dpAutoRigSystem/Validator/CheckOut/dpColorSetCleaner.py
+++ b/dpAutoRigSystem/Validator/CheckOut/dpColorSetCleaner.py
@@ -8,7 +8,7 @@ TITLE = "v030_colorSetCleaner"
 DESCRIPTION = "v031_colorSetCleanerDesc"
 ICON = "/Icons/dp_colorSetCleaner.png"
 
-DP_COLORSETCLEANER_VERSION = 1.1
+DP_COLORSETCLEANER_VERSION = 1.2
 
 
 class ColorSetCleaner(dpBaseValidatorClass.ValidatorStartClass):
@@ -56,7 +56,8 @@ class ColorSetCleaner(dpBaseValidatorClass.ValidatorStartClass):
                     self.resultOkList.append(False)
                 else: #fix
                     try:
-                        cmds.delete(item)
+                        if cmds.objExists(item):
+                            cmds.delete(item)
                         cmds.select(clear=True)
                         self.resultOkList.append(True)
                         self.messageList.append(self.dpUIinst.lang['v004_fixed']+": "+item)

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -18,8 +18,8 @@
 ###################################################################
 
 
-DPAR_VERSION_PY3 = "4.03.45"
-DPAR_UPDATELOG = "N773 - Added conditional on dpRivet FaceToRivet to check \nMaya's version when using morphDeformer to avoid geometry missplacing. \nMinimal Maya's version: 2022.3."
+DPAR_VERSION_PY3 = "4.03.46"
+DPAR_UPDATELOG = "N771 - ColorSet cleaner fixed issue and report False"
 
 
 


### PR DESCRIPTION
It checks if the colorset node exists before trying to delete it.