### PR TITLE
N784 Geometry history ignore node type list

### DIFF
--- a/dpAutoRigSystem/Validator/CheckIn/dpGeometryHistory.py
+++ b/dpAutoRigSystem/Validator/CheckIn/dpGeometryHistory.py
@@ -8,7 +8,7 @@ TITLE = "v071_geometryHistory"
 DESCRIPTION = "v072_geometryHistoryDesc"
 ICON = "/Icons/dp_geometryHistory.png"
 
-DP_GEOMETRYHISTORY_VERSION = 1.1
+DP_GEOMETRYHISTORY_VERSION = 1.2
 
 
 class GeometryHistory(dpBaseValidatorClass.ValidatorStartClass):
@@ -37,6 +37,7 @@ class GeometryHistory(dpBaseValidatorClass.ValidatorStartClass):
 
         # ---
         # --- validator code --- beginning
+        ignoreTypeList = ["tweak", "file", "place2dTexture"]
         if objList:
             geoToCleanList = objList
         else:
@@ -52,7 +53,7 @@ class GeometryHistory(dpBaseValidatorClass.ValidatorStartClass):
                         if historyList:
                             for history in historyList:
                                 # Pass through tweak and initialShading nodes
-                                if cmds.nodeType(history) != "tweak": 
+                                if not cmds.nodeType(history) in ignoreTypeList: 
                                     if history != "initialShadingGroup":
                                         geoList.append(transform)
             # Merge duplicated names

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -18,8 +18,8 @@
 ###################################################################
 
 
-DPAR_VERSION_PY3 = "4.03.52"
-DPAR_UPDATELOG = "N770 - Fixed saved root folder file issue."
+DPAR_VERSION_PY3 = "4.03.53"
+DPAR_UPDATELOG = "N784 - Added ignore node type list to\nGeometry History checkin validator."
 
 
 


### PR DESCRIPTION
Fixed the Geometry History checkin validator to avoid found issue when the mesh shape has input connections by texture nodes. Added an ignoreNodeTypeList.