### PR TITLE
N463 reverse foot ctrl display

### DIFF
--- a/dpAutoRigSystem/Modules/Library/dpSoftIk.py
+++ b/dpAutoRigSystem/Modules/Library/dpSoftIk.py
@@ -29,7 +29,7 @@
 from maya import cmds
 from . import dpControls
 
-DP_SOFTIK_VERSION = 2.0
+DP_SOFTIK_VERSION = 2.1
 
 
 class SoftIkClass(object):
@@ -118,10 +118,13 @@ class SoftIkClass(object):
         # if stretch exists, we need to do this...
         if stretch:
             softRatioMD = cmds.createNode("multiplyDivide", name=userName+"_Soft_Ratio_MD")
+            disableFkStretchMD = cmds.createNode("multiplyDivide", name=userName+"_DisableFkStretch_MD")
             stretchBC = cmds.createNode("blendColors", name=userName+"_Stretch_BC")
             cmds.setAttr(softRatioMD+".operation", 2) #divide
             cmds.setAttr(stretchBC+".color2R", 1)
-            cmds.connectAttr(ctrlName+".stretchable", stretchBC+".blender", force=True)
+            cmds.connectAttr(ctrlName+".stretchable", disableFkStretchMD+".input1X", force=True)
+            cmds.connectAttr(ctrlName+".disableIkFkRevOutputX", disableFkStretchMD+".input2X", force=True)
+            cmds.connectAttr(disableFkStretchMD+".outputX", stretchBC+".blender", force=True)
             cmds.connectAttr(distBetween+".distance", softRatioMD+".input1X", force=True)
             cmds.connectAttr(daCnd+".outColorR", softRatioMD+".input2X", force=True)
             cmds.connectAttr(distDiffPMA+".output1D", stretchBC+".color2G", force=True)

--- a/dpAutoRigSystem/Modules/dpFoot.py
+++ b/dpAutoRigSystem/Modules/dpFoot.py
@@ -445,7 +445,7 @@ class Foot(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                 mdNode = cmds.createNode("multiplyDivide", name=side+self.userGuideName+"_Vis_MD")
                 cmds.connectAttr(self.footCtrl+".visIkFk", mdNode+".input2X", force=True)
                 cmds.connectAttr(self.footCtrl+"."+showCtrlsAttr, mdNode+".input1X", force=True)
-                showHideCtrlList = [self.RFACtrl, self.RFBCtrl, self.RFCCtrl, self.RFDCtrl]
+                showHideCtrlList = [self.RFACtrl, self.RFBCtrl, self.RFCCtrl, self.RFDCtrl, self.RFECtrl]
                 for rfCtrl in showHideCtrlList:
                     rfCtrlShape = cmds.listRelatives(rfCtrl, children=True, type='nurbsCurve')[0]
                     cmds.connectAttr(mdNode+".outputX", rfCtrlShape+".visibility", force=True)

--- a/dpAutoRigSystem/Modules/dpFoot.py
+++ b/dpAutoRigSystem/Modules/dpFoot.py
@@ -10,7 +10,7 @@ TITLE = "m024_foot"
 DESCRIPTION = "m025_footDesc"
 ICON = "/Icons/dp_foot.png"
 
-DP_FOOT_VERSION = 2.2
+DP_FOOT_VERSION = 2.3
 
 
 class Foot(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
@@ -441,10 +441,14 @@ class Foot(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                 # show or hide reverseFoot controls:
                 cmds.addAttr(self.footCtrl, longName=showCtrlsAttr, attributeType='short', minValue=0, defaultValue=1, maxValue=1)
                 cmds.setAttr(self.footCtrl+"."+showCtrlsAttr, keyable=False, channelBox=True)
+                cmds.addAttr(self.footCtrl, longName="visIkFk", attributeType='float', minValue=0, defaultValue=1, maxValue=1, keyable=False)
+                mdNode = cmds.createNode("multiplyDivide", name=side+self.userGuideName+"_Vis_MD")
+                cmds.connectAttr(self.footCtrl+".visIkFk", mdNode+".input2X", force=True)
+                cmds.connectAttr(self.footCtrl+"."+showCtrlsAttr, mdNode+".input1X", force=True)
                 showHideCtrlList = [self.RFACtrl, self.RFBCtrl, self.RFCCtrl, self.RFDCtrl]
                 for rfCtrl in showHideCtrlList:
                     rfCtrlShape = cmds.listRelatives(rfCtrl, children=True, type='nurbsCurve')[0]
-                    cmds.connectAttr(self.footCtrl+"."+showCtrlsAttr, rfCtrlShape+".visibility", force=True)
+                    cmds.connectAttr(mdNode+".outputX", rfCtrlShape+".visibility", force=True)
                 
                 # create a masterModuleGrp to be checked if this rig exists:
                 self.toCtrlHookGrp = cmds.group(self.footCtrlZeroList[0], name=side+self.userGuideName+"_Control_Grp")

--- a/dpAutoRigSystem/Modules/dpLimb.py
+++ b/dpAutoRigSystem/Modules/dpLimb.py
@@ -20,7 +20,7 @@ ICON = "/Icons/dp_limb.png"
 ARM = "Arm"
 LEG = "Leg"
 
-DP_LIMB_VERSION = 2.7
+DP_LIMB_VERSION = 2.8
 
 
 class Limb(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
@@ -1036,7 +1036,7 @@ class Limb(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                 
                 # quadExtraCtrl autoOrient setup:
                 if self.limbStyle == self.dpUIinst.lang['m155_quadrupedExtra']:
-                    cmds.addAttr(self.quadExtraCtrl, longName='autoOrient', attributeType='float', min=0, max=1, defaultValue=1, keyable=True)
+                    cmds.addAttr(self.quadExtraCtrl, longName='autoOrient', attributeType='float', minValue=0, max=1, defaultValue=1, keyable=True)
                     cmds.setAttr(self.quadExtraCtrl+".autoOrient", 0)
                     quadExtraRotNull = cmds.group(name=self.quadExtraCtrl+"_AutoOrient_Null", empty=True)
                     cmds.delete(cmds.parentConstraint(self.quadExtraCtrl, quadExtraRotNull, maintainOffset=False))
@@ -1120,13 +1120,13 @@ class Limb(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                 cmds.connectAttr(self.worldRef+"."+attrNameLower+'Fk_ikFkBlend', parentConstToRFOffset+"."+self.fkCtrlList[len(self.fkCtrlList) - 1]+"W1", force=True)
 
                 # work with scalable extrem hand or foot:
-                cmds.addAttr(self.fkCtrlList[-1], ln=self.dpUIinst.lang['c040_uniformScale'], at="double", min=0.001, dv=1)
-                cmds.addAttr(self.ikExtremCtrl, ln=self.dpUIinst.lang['c040_uniformScale'], at="double", min=0.001, dv=1)
+                cmds.addAttr(self.fkCtrlList[-1], longName=self.dpUIinst.lang['c040_uniformScale'], attributeType="double", minValue=0.001, defaultValue=1)
+                cmds.addAttr(self.ikExtremCtrl, longName=self.dpUIinst.lang['c040_uniformScale'], attributeType="double", minValue=0.001, defaultValue=1)
                 cmds.setAttr(self.fkCtrlList[-1]+"."+self.dpUIinst.lang['c040_uniformScale'], edit=True, keyable=True)
                 cmds.setAttr(self.ikExtremCtrl+"."+self.dpUIinst.lang['c040_uniformScale'], edit=True, keyable=True)
                 # add scale multiplier attribute
-                cmds.addAttr(self.fkCtrlList[-1], ln=self.dpUIinst.lang['c040_uniformScale']+self.dpUIinst.lang['c105_multiplier'].capitalize(), at='double', min=0.001, dv=1)
-                cmds.addAttr(self.ikExtremCtrl, ln=self.dpUIinst.lang['c040_uniformScale']+self.dpUIinst.lang['c105_multiplier'].capitalize(), at='double', min=0.001, dv=1)
+                cmds.addAttr(self.fkCtrlList[-1], longName=self.dpUIinst.lang['c040_uniformScale']+self.dpUIinst.lang['c105_multiplier'].capitalize(), attributeType='double', minValue=0.001, defaultValue=1)
+                cmds.addAttr(self.ikExtremCtrl, longName=self.dpUIinst.lang['c040_uniformScale']+self.dpUIinst.lang['c105_multiplier'].capitalize(), attributeType='double', minValue=0.001, defaultValue=1)
                 ikScaleMD = cmds.rename(cmds.createNode('multiplyDivide'), side+self.userGuideName+"_"+self.dpUIinst.lang['c105_multiplier'].capitalize()+'_Ik_MD')
                 fkScaleMD = cmds.rename(cmds.createNode('multiplyDivide'), side+self.userGuideName+"_"+self.dpUIinst.lang['c105_multiplier'].capitalize()+'_Fk_MD')
                 cmds.connectAttr(self.ikExtremCtrl+"."+self.dpUIinst.lang['c040_uniformScale'], ikScaleMD+".input1X", force=True)
@@ -1188,6 +1188,10 @@ class Limb(dpBaseClass.StartClass, dpLayoutClass.LayoutClass):
                 cmds.setAttr(ikStretchClp+".maxR", 1)
                 cmds.connectAttr(ikStretchCnd+".outColorR", ikStretchClp+".inputR", force=True)
                 cmds.connectAttr(ikStretchClp+".outputR", parentConstToRFOffset+"."+self.ikNSJointList[-2]+"W2", force=True)
+
+                # prepare to disable stretch in fk mode
+                cmds.addAttr(self.ikExtremCtrl, longName="disableIkFkRevOutputX", attributeType="double", keyable=False)
+                cmds.connectAttr(self.worldRef+"."+attrNameLower+"Fk_ikFkBlendRevOutputX", self.ikExtremCtrl+".disableIkFkRevOutputX", force=True)
 
                 # create a masterModuleGrp to be checked if this rig exists:
                 if self.limbTypeName == ARM:

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -18,8 +18,8 @@
 ###################################################################
 
 
-DPAR_VERSION_PY3 = "4.03.53"
-DPAR_UPDATELOG = "N463 - Hide reverseFoot ctrls if in Fk mode.\nN721 - Hide Foot_Ball_Ctrl when Limb in FK."
+DPAR_VERSION_PY3 = "4.03.54"
+DPAR_UPDATELOG = "N463 - Hide reverseFoot ctrls if in Fk mode.\nN721 - Hide Foot_Ball_Ctrl when Limb in FK.\nN755 - Disable ik stretch when in fk mode."
 
 
 

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -19,7 +19,7 @@
 
 
 DPAR_VERSION_PY3 = "4.03.53"
-DPAR_UPDATELOG = "N463 - Hide reverseFoot ctrls if in Fk mode."
+DPAR_UPDATELOG = "N463 - Hide reverseFoot ctrls if in Fk mode.\nN721 - Hide Foot_Ball_Ctrl when Limb in FK."
 
 
 

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -19,7 +19,7 @@
 
 
 DPAR_VERSION_PY3 = "4.03.53"
-DPAR_UPDATELOG = "N784 - Added ignore node type list to\nGeometry History checkin validator."
+DPAR_UPDATELOG = "N463 - Hide reverseFoot ctrls if in Fk mode."
 
 
 
@@ -2533,7 +2533,7 @@ class DP_AutoRig_UI(object):
                                     extremJnt             = self.integratedTaskDic[fatherGuide]['extremJntList'][s]
                                     ikStretchExtremLoc    = self.integratedTaskDic[fatherGuide]['ikStretchExtremLoc'][s]
                                     limbTypeName          = self.integratedTaskDic[fatherGuide]['limbTypeName']
-                                    worldRefList          = self.integratedTaskDic[fatherGuide]['worldRefList'][s]
+                                    worldRef              = self.integratedTaskDic[fatherGuide]['worldRefList'][s]
                                     addArticJoint         = self.integratedTaskDic[fatherGuide]['addArticJoint']
                                     addCorrective         = self.integratedTaskDic[fatherGuide]['addCorrective']
                                     ankleArticList        = self.integratedTaskDic[fatherGuide]['ankleArticList'][s]
@@ -2606,6 +2606,14 @@ class DP_AutoRig_UI(object):
                                             if not keyableStatus:
                                                 cmds.setAttr(ikCtrl+'.'+attr, channelBox=channelBoxStatus)
                                             cmds.connectAttr(ikCtrl+'.'+attr, revFootCtrl+'.'+attr, force=True)
+                                            if attr == "visIkFk":
+                                                if not cmds.objExists(worldRef):
+                                                    worldRef = worldRef.replace("_Ctrl", "_Grp")
+                                                if cmds.objExists(worldRef):
+                                                    wrAttrList = cmds.listAttr(worldRef, userDefined=True)
+                                                    for wrAttr in wrAttrList:
+                                                        if "Fk_ikFkBlendRevOutputX" in wrAttr:
+                                                            cmds.connectAttr(worldRef+"."+wrAttr, ikCtrl+'.'+attr, force=True)
                                     revFootCtrlOld = cmds.rename(revFootCtrl, revFootCtrl+"_Old")
                                     self.customAttr.removeAttr("dpControl", [revFootCtrlOld])
                         
@@ -2644,7 +2652,7 @@ class DP_AutoRig_UI(object):
                                 # connect Option_Ctrl RigScale_MD output to the radiusScale:
                                 if cmds.objExists(self.rigScaleMD+".dpRigScale") and cmds.getAttr(self.rigScaleMD+".dpRigScale") == True:
                                     cmds.connectAttr(self.rigScaleMD+".outputX", softIkCalibList[w]+".input2X", force=True)
-                                
+
                                 cmds.delete(worldRefShapeList[w])
                                 worldRef = cmds.rename(worldRef, worldRef.replace("_Ctrl", "_Grp"))
                                 cmds.parentConstraint(self.rootCtrl, worldRef, maintainOffset=True, name=worldRef+"_PaC")
@@ -2654,8 +2662,8 @@ class DP_AutoRig_UI(object):
                             
                                 # fix poleVector follow feature integrating with Master_Ctrl and Root_Ctrl:
                                 cmds.parentConstraint(self.masterCtrl, masterCtrlRefList[w], maintainOffset=True, name=masterCtrlRefList[w]+"_PaC")
-                                rootPacConst = cmds.parentConstraint(self.rootCtrl, rootCtrlRefList[w], maintainOffset=True, name=rootCtrlRefList[w]+"_PaC")
-
+                                cmds.parentConstraint(self.rootCtrl, rootCtrlRefList[w], maintainOffset=True, name=rootCtrlRefList[w]+"_PaC")
+                            
                             # parenting correctly the ikCtrlZero to spineModule:
                             fatherModule   = self.hookDic[moduleDic]['fatherModule']
                             fatherGuideLoc = self.hookDic[moduleDic]['fatherGuideLoc']


### PR DESCRIPTION
Worked the controllers visibility and stretch disable when in fk mode, for these tasks:
N463 - Hide reverseFoot ctrls if in Fk mode
N721 - Hide Foot_Ball_Ctrl when Limb in FK
N755 - Disable ik stretch when in fk mode