### PR TITLE
N811-root-pivot-control

### DIFF
--- a/dpAutoRigSystem/Controls/Presets/Classic.json
+++ b/dpAutoRigSystem/Controls/Presets/Classic.json
@@ -2,7 +2,7 @@
     "_preset"     : "Classic",
     "_author"     : "Danilo Pinheiro",
     "_date"       : "2019-12-05",
-    "_updated"    : "2023-12-29",
+    "_updated"    : "2024-03-29",
 
     "id_000_Base"             : {"type" : "Circle",           "degree" : 1},
     "id_001_Locator"          : {"type" : "Locator",          "degree" : 1},
@@ -102,5 +102,6 @@
     "id_095_LimbMainSub"      : {"type" : "Ball",             "degree" : 3},
     "id_096_FkLineMain"       : {"type" : "Circle",           "degree" : 3},
     "id_097_HeadDeformerMain" : {"type" : "Circle",           "degree" : 3},
-    "id_098_HeadDeformerSub"  : {"type" : "Square",           "degree" : 3}
+    "id_098_HeadDeformerSub"  : {"type" : "Square",           "degree" : 3},
+    "id_099_RootPivot"        : {"type" : "Locator",          "degree" : 3}
 }

--- a/dpAutoRigSystem/Controls/Presets/Cubic.json
+++ b/dpAutoRigSystem/Controls/Presets/Cubic.json
@@ -2,7 +2,7 @@
     "_preset"     : "Cubic",
     "_author"     : "Danilo Pinheiro",
     "_date"       : "2019-12-05",
-    "_updated"    : "2023-12-29",
+    "_updated"    : "2024-03-29",
 
     "id_000_Base"             : {"type" : "Cube", "degree" : 1},
     "id_001_Locator"          : {"type" : "Cube", "degree" : 1},
@@ -102,5 +102,6 @@
     "id_095_LimbMainSub"      : {"type" : "Cube", "degree" : 1},
     "id_096_FkLineMain"       : {"type" : "Cube", "degree" : 1},
     "id_097_HeadDeformerMain" : {"type" : "Cube", "degree" : 1},
-    "id_098_HeadDeformerSub"  : {"type" : "Cube", "degree" : 1}
+    "id_098_HeadDeformerSub"  : {"type" : "Cube", "degree" : 1},
+    "id_099_RootPivot"        : {"type" : "Cube", "degree" : 1}
 }

--- a/dpAutoRigSystem/Controls/Presets/Default.json
+++ b/dpAutoRigSystem/Controls/Presets/Default.json
@@ -2,7 +2,7 @@
     "_preset"     : "Default",
     "_author"     : "Danilo Pinheiro",
     "_date"       : "2019-12-03",
-    "_updated"    : "2023-12-29",
+    "_updated"    : "2024-03-29",
 
     "id_000_Base"             : {"type" : "Circle",           "degree" : 1},
     "id_001_Locator"          : {"type" : "Locator",          "degree" : 1},
@@ -102,5 +102,6 @@
     "id_095_LimbMainSub"      : {"type" : "Ball",             "degree" : 3},
     "id_096_FkLineMain"       : {"type" : "Circle",           "degree" : 3},
     "id_097_HeadDeformerMain" : {"type" : "Cube",             "degree" : 3},
-    "id_098_HeadDeformerSub"  : {"type" : "Square",           "degree" : 3}
+    "id_098_HeadDeformerSub"  : {"type" : "Square",           "degree" : 3},
+    "id_099_RootPivot"        : {"type" : "Locator",          "degree" : 3}
 }

--- a/dpAutoRigSystem/Extras/dpLimbSpaceSwitch.py
+++ b/dpAutoRigSystem/Extras/dpLimbSpaceSwitch.py
@@ -7,7 +7,7 @@ TITLE = "m059_limbSpaceSwitch"
 DESCRIPTION = "m060_limbSpaceSwitchDesc"
 ICON = "/Icons/dp_limbSpaceSwitch.png"
 
-DP_LIMBSPACESWITCH_VERSION = 2.1
+DP_LIMBSPACESWITCH_VERSION = 2.2
 
 
 class LimbSpaceSwitch(object):
@@ -29,9 +29,15 @@ class LimbSpaceSwitch(object):
         self.spineChestACtrl = self.spineName+"_"+self.chestName+"A_Ctrl"
         self.spineChestBCtrl = self.spineName+"_"+self.chestName+"B_Ctrl"
         self.headSubCtrl = self.headName+"_"+self.headName+"_Sub_Ctrl"
-
         self.followAttr = self.dpUIinst.lang['c032_follow']
         
+        # find ctrls visibility grp to use instead root ctrl
+        childrenList = cmds.listRelatives(self.rootCtrl, children=True)
+        if childrenList:
+            for child in childrenList:
+                if child.find("_Visibility_Grp") != -1:
+                    self.rootCtrl = child
+
         # call main function
         self.dpMain(self)
     

--- a/dpAutoRigSystem/Extras/dpLimbSpaceSwitch.py
+++ b/dpAutoRigSystem/Extras/dpLimbSpaceSwitch.py
@@ -15,31 +15,29 @@ class LimbSpaceSwitch(object):
         # redeclaring variables
         self.dpUIinst = dpUIinst
         
-        self.globalName = "Global"
-        self.rootName = "Root"
-        self.spineName = self.dpUIinst.lang['m011_spine']
-        self.hipsName = self.dpUIinst.lang['c027_hips']
-        self.headName = self.dpUIinst.lang['c024_head']
-        self.chestName = self.dpUIinst.lang['c028_chest']
-        
-        self.globalCtrl = self.globalName+"_Ctrl"
-        self.rootCtrl = self.rootName+"_Ctrl"
-        self.spineHipsACtrl = self.spineName+"_"+self.hipsName+"A_Ctrl"
-        self.spineHipsBCtrl = self.spineName+"_"+self.hipsName+"B_Ctrl"
-        self.spineChestACtrl = self.spineName+"_"+self.chestName+"A_Ctrl"
-        self.spineChestBCtrl = self.spineName+"_"+self.chestName+"B_Ctrl"
-        self.headSubCtrl = self.headName+"_"+self.headName+"_Sub_Ctrl"
-        self.followAttr = self.dpUIinst.lang['c032_follow']
-        
-        # find ctrls visibility grp to use instead root ctrl
-        childrenList = cmds.listRelatives(self.rootCtrl, children=True)
-        if childrenList:
-            for child in childrenList:
-                if child.find("_Visibility_Grp") != -1:
-                    self.rootCtrl = child
+        # find nodes
+        for item in cmds.ls(selection=False, type="transform"):
+            if cmds.objExists(item+".masterGrp"): #All_Grp
+                self.rootCtrl = cmds.listConnections(item+".ctrlsVisibilityGrp", source=True, destination=False)[0] #Ctrls_Visibility_Grp
+                self.globalCtrl = cmds.listConnections(item+".globalCtrl", source=True, destination=False)[0]
 
-        # call main function
-        self.dpMain(self)
+                self.globalName = "Global"
+                self.rootName = "Root"
+
+                self.spineName = self.dpUIinst.lang['m011_spine']
+                self.hipsName = self.dpUIinst.lang['c027_hips']
+                self.headName = self.dpUIinst.lang['c024_head']
+                self.chestName = self.dpUIinst.lang['c028_chest']
+                
+                self.spineHipsACtrl = self.spineName+"_"+self.hipsName+"A_Ctrl"
+                self.spineHipsBCtrl = self.spineName+"_"+self.hipsName+"B_Ctrl"
+                self.spineChestACtrl = self.spineName+"_"+self.chestName+"A_Ctrl"
+                self.spineChestBCtrl = self.spineName+"_"+self.chestName+"B_Ctrl"
+                self.headSubCtrl = self.headName+"_"+self.headName+"_Sub_Ctrl"
+                self.followAttr = self.dpUIinst.lang['c032_follow']
+
+                # call main function
+                self.dpMain(self)
     
     
     def dpMain(self, *args):

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -2178,15 +2178,12 @@ class DP_AutoRig_UI(object):
         # set lock and hide attributes
         self.ctrls.setLockHide([self.scalableGrp], ['tx', 'ty', 'tz', 'rx', 'ry', 'rz', 'v'])
         self.ctrls.setLockHide([self.rootCtrl, self.globalCtrl], ['sx', 'sy', 'sz', 'v'])
-        self.ctrls.setLockHide([self.rootPivotCtrl], ['rx', 'ry', 'rz', 'sx', 'sy', 'sz', 'v'])
+        self.ctrls.setLockHide([self.rootPivotCtrl], ['rx', 'ry', 'rz', 'sx', 'sy', 'sz', 'v', 'ro'])
 
         # root pivot control setup
-        cmds.connectAttr(self.rootPivotCtrl+".translateX", self.rootCtrl+".rotatePivotX")
-        cmds.connectAttr(self.rootPivotCtrl+".translateY", self.rootCtrl+".rotatePivotY")
-        cmds.connectAttr(self.rootPivotCtrl+".translateZ", self.rootCtrl+".rotatePivotZ")
-        cmds.connectAttr(self.rootPivotCtrl+".translateX", self.rootCtrl+".scalePivotX")
-        cmds.connectAttr(self.rootPivotCtrl+".translateY", self.rootCtrl+".scalePivotY")
-        cmds.connectAttr(self.rootPivotCtrl+".translateZ", self.rootCtrl+".scalePivotZ")
+        for axis in ["X", "Y", "Z"]:
+            cmds.connectAttr(self.rootPivotCtrl+".translate"+axis, self.rootCtrl+".rotatePivot"+axis)
+            cmds.connectAttr(self.rootPivotCtrl+".translate"+axis, self.rootCtrl+".scalePivot"+axis)
 
         cmds.setAttr(self.masterCtrl+".visibility", keyable=False)
         cmds.select(None)

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -18,8 +18,8 @@
 ###################################################################
 
 
-DPAR_VERSION_PY3 = "4.04.06"
-DPAR_UPDATELOG = "N801 - Prompt for exclude faceToRivet\nand lock empty groups."
+DPAR_VERSION_PY3 = "4.04.07"
+DPAR_UPDATELOG = "N811 - Implemented Root pivot controller setup."
 
 
 
@@ -2143,10 +2143,12 @@ class DP_AutoRig_UI(object):
         self.masterCtrl = self.getBaseCtrl("id_004_Master", "masterCtrl", self.prefix+"Master_Ctrl", fMasterRadius, iDegree=3)
         self.globalCtrl = self.getBaseCtrl("id_003_Global", "globalCtrl", self.prefix+"Global_Ctrl", self.ctrls.dpCheckLinearUnit(13))
         self.rootCtrl   = self.getBaseCtrl("id_005_Root", "rootCtrl", self.prefix+"Root_Ctrl", self.ctrls.dpCheckLinearUnit(8))
+        self.rootPivotCtrl = self.getBaseCtrl("id_099_RootPivot", "rootPivotCtrl", self.prefix+"Root_Pivot_Ctrl", self.ctrls.dpCheckLinearUnit(1), iDegree=3)
         self.optionCtrl = self.getBaseCtrl("id_006_Option", "optionCtrl", self.prefix+"Option_Ctrl", self.ctrls.dpCheckLinearUnit(16))
         if (self.ctrlCreated):
             cmds.makeIdentity(self.optionCtrl, apply=True)
             self.optionCtrlGrp = dpUtils.zeroOut([self.optionCtrl])[0]
+            self.rootPivotCtrlGrp = dpUtils.zeroOut([self.rootPivotCtrl])[0]
             cmds.setAttr(self.optionCtrlGrp+".translateX", fMasterRadius)
             # use Option_Ctrl rigScale and rigScaleMultiplier attribute to Master_Ctrl
             self.rigScaleMD = cmds.createNode("multiplyDivide", name=self.prefix+'RigScale_MD')
@@ -2164,6 +2166,7 @@ class DP_AutoRig_UI(object):
             self.ctrls.setLockHide([self.optionCtrl], ['rigScaleOutput'])
             self.ctrls.setNonKeyable([self.optionCtrl], ['tx', 'ty', 'tz', 'rx', 'ry', 'rz', 'sx', 'sy', 'sz', 'v'])
             self.ctrls.setCalibrationAttr(self.optionCtrl, ['rigScaleMultiplier'])
+            cmds.parent(self.rootPivotCtrlGrp, self.rootCtrl)
             cmds.parent(self.rootCtrl, self.masterCtrl)
             cmds.parent(self.masterCtrl, self.globalCtrl)
             cmds.parent(self.globalCtrl, self.ctrlsGrp)
@@ -2175,6 +2178,15 @@ class DP_AutoRig_UI(object):
         # set lock and hide attributes
         self.ctrls.setLockHide([self.scalableGrp], ['tx', 'ty', 'tz', 'rx', 'ry', 'rz', 'v'])
         self.ctrls.setLockHide([self.rootCtrl, self.globalCtrl], ['sx', 'sy', 'sz', 'v'])
+        self.ctrls.setLockHide([self.rootPivotCtrl], ['rx', 'ry', 'rz', 'sx', 'sy', 'sz', 'v'])
+
+        # root pivot control setup
+        cmds.connectAttr(self.rootPivotCtrl+".translateX", self.rootCtrl+".rotatePivotX")
+        cmds.connectAttr(self.rootPivotCtrl+".translateY", self.rootCtrl+".rotatePivotY")
+        cmds.connectAttr(self.rootPivotCtrl+".translateZ", self.rootCtrl+".rotatePivotZ")
+        cmds.connectAttr(self.rootPivotCtrl+".translateX", self.rootCtrl+".scalePivotX")
+        cmds.connectAttr(self.rootPivotCtrl+".translateY", self.rootCtrl+".scalePivotY")
+        cmds.connectAttr(self.rootPivotCtrl+".translateZ", self.rootCtrl+".scalePivotZ")
 
         cmds.setAttr(self.masterCtrl+".visibility", keyable=False)
         cmds.select(None)
@@ -3086,7 +3098,12 @@ class DP_AutoRig_UI(object):
                     cmds.addAttr(self.optionCtrl, longName="control", min=0, max=1, defaultValue=1, attributeType="long", keyable=False)
                     cmds.connectAttr(self.optionCtrl+".control", self.ctrlsVisGrp+".visibility", force=True)
                     cmds.setAttr(self.optionCtrl+".control", channelBox=True)
-                
+
+                if not cmds.objExists(self.optionCtrl+".rootPivot"):
+                    cmds.addAttr(self.optionCtrl, longName="rootPivot", min=0, max=1, defaultValue=0, attributeType="long", keyable=False)
+                    cmds.connectAttr(self.optionCtrl+".rootPivot", self.rootPivotCtrlGrp+".visibility", force=True)
+                    cmds.setAttr(self.optionCtrl+".rootPivot", channelBox=True)
+
                 # try to organize Option_Ctrl attributes:
                 # get current user defined attributes:
                 currentAttrList = cmds.listAttr(self.optionCtrl, userDefined=True)
@@ -3115,7 +3132,7 @@ class DP_AutoRig_UI(object):
                 'tailFk', 'tailDyn', 'tail1Fk', 'tail1Dyn', 'tailFk1', 'tailDyn1', leftAttr+'TailFk', leftAttr+'TailFk1', rightAttr+'TailFk', rightAttr+'TailFk1', leftAttr+'TailDyn', leftAttr+'TailDyn1', rightAttr+'TailDyn', rightAttr+'TailDyn1',
                 'hairFk', 'hairDyn', 'hair1Fk', 'hair1Dyn', 'hairFk1', 'hairDyn1', leftAttr+'HairFk', leftAttr+'HairFk1', rightAttr+'HairFk', rightAttr+'HairFk1', leftAttr+'HairDyn', leftAttr+'HairDyn1', rightAttr+'HairDyn', rightAttr+'HairDyn1',
                 'dpAR_1Fk', 'dpAR_1Dyn', 'dpAR_2Fk', 'dpAR_2Dyn', 'dpAR_1Fk1', 'dpAR_1Dyn1', leftAttr+'dpAR_1Fk', leftAttr+'dpAR_1Fk1', rightAttr+'dpAR_1Fk', rightAttr+'dpAR_1Fk1', leftAttr+'dpAR_1Dyn', leftAttr+'dpAR_1Dyn1', rightAttr+'dpAR_1Dyn', rightAttr+'dpAR_1Dyn1',
-                'display', 'mesh', 'proxy', 'control', 'bends', 'extraBends', tweaksAttr, 'correctiveCtrls']
+                'display', 'mesh', 'proxy', 'control', 'rootPivot', 'bends', 'extraBends', tweaksAttr, 'correctiveCtrls']
                 # call method to reorder Option_Ctrl attributes:
                 self.reorderAttributes([self.optionCtrl], desiredAttrList)
                 


### PR DESCRIPTION
Implemented root pivot control setup. The new controller will connect translate to the root_ctrl's rotate pivot. Changed limbSpaceSwitch to use Ctrls_Visiblity_Grp instead Root_Ctrl.