### PR TITLE
N813 Custom asset name to publishing files

### DIFF
--- a/dpAutoRigSystem/Pipeline/dpPipeliner.py
+++ b/dpAutoRigSystem/Pipeline/dpPipeliner.py
@@ -22,6 +22,7 @@ class Pipeliner(object):
         self.webhookFile = "dpWebhook.json"
         self.hookFile = "dpHook.json"
         self.callbackFile = "dpPublishCallback.py"
+        self.customAssetNameFile = "dpCustomAssetName.json"
         self.pipeData = self.getPipelineData()
         self.declarePipelineAnnotation()
         
@@ -85,7 +86,7 @@ class Pipeliner(object):
         """
         jsonHookPath = os.path.join(os.path.dirname(os.path.abspath(__file__)), self.hookFile).replace("\\", "/")
         return self.updateDataByJsonPath(jsonHookPath)
-
+    
 
     def getInfoByPath(self, field, dependent, path=None, cut=False, *args):
         """ Use field as the given data to return the result about.
@@ -112,6 +113,19 @@ class Pipeliner(object):
             self.pipeData[field] = name
             return self.pipeData[field]
 
+
+    def getCustomAssetNameInfo(self, assetName, *args):
+        """ Returns the path content of the dpCustomAssetName json file if it exists.
+            Otherwise returns the given assetName.
+        """
+        if assetName:
+            if os.path.exists(self.pipeData['path']+"/"+self.customAssetNameFile):
+                content = self.getJsonContent(self.pipeData['path']+"/"+self.customAssetNameFile)
+                if content:
+                    if assetName in list(content.keys()):
+                        return content[assetName]
+        return assetName
+    
 
     def declareDefaultPipelineInfo(self, *args):
         """ Returns a default pipeline info data to load the UI if there isn't any.

--- a/dpAutoRigSystem/Pipeline/dpPublisher.py
+++ b/dpAutoRigSystem/Pipeline/dpPublisher.py
@@ -7,7 +7,7 @@ from . import dpPackager
 from functools import partial
 import os
 
-DP_PUBLISHER_VERSION = 1.8
+DP_PUBLISHER_VERSION = 1.9
 
 
 class Publisher(object):
@@ -167,20 +167,22 @@ class Publisher(object):
 
     def getPipeFileName(self, filePath, *args):
         """ Return the generated file name based on the pipeline publish folder.
-            It's check the asset name and define the file version to save the published file.
+            It checks the asset name and define the file version to save the published file.
         """
         self.assetNameList = []
         if os.path.exists(filePath):
             self.pipeliner.pipeData['assetNameFolderIssue'] = False
             assetName = self.checkPipelineAssetNameFolder()
+            customAssetName = self.pipeliner.getCustomAssetNameInfo(assetName)
             if not assetName:
                 assetName = self.shortAssetName
+                customAssetName = self.shortAssetName
                 self.pipeliner.pipeData['assetNameFolderIssue'] = True
             publishVersion = 1 #starts the number versioning by one to have the first delivery file as _v001.
             fileNameList = next(os.walk(filePath))[2]
             if fileNameList:
                 for fileName in fileNameList:
-                    if assetName+self.pipeliner.pipeData['s_middle'] in fileName:
+                    if customAssetName+self.pipeliner.pipeData['s_middle'] in fileName:
                         if not fileName in self.assetNameList:
                             self.assetNameList.append(fileName)
                 if self.assetNameList:
@@ -192,9 +194,10 @@ class Publisher(object):
             elif self.pipeliner.pipeData['b_upper']:
                 assetName = assetName.upper()
             self.pipeliner.pipeData['assetName'] = assetName
+            self.pipeliner.pipeData['customAssetName'] = customAssetName
             self.pipeliner.pipeData['rigVersion'] = self.getRigWIPVersion()
             self.pipeliner.pipeData['publishVersion'] = publishVersion
-            fileName = self.pipeliner.pipeData['s_prefix']+assetName+self.pipeliner.pipeData['s_middle']+(str(publishVersion).zfill(int(self.pipeliner.pipeData['i_padding']))+self.pipeliner.pipeData['s_suffix'])
+            fileName = self.pipeliner.pipeData['s_prefix']+customAssetName+self.pipeliner.pipeData['s_middle']+(str(publishVersion).zfill(int(self.pipeliner.pipeData['i_padding']))+self.pipeliner.pipeData['s_suffix'])
             return fileName
         else:
             return False

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -18,8 +18,8 @@
 ###################################################################
 
 
-DPAR_VERSION_PY3 = "4.04.07"
-DPAR_UPDATELOG = "N811 - Implemented Root pivot controller setup."
+DPAR_VERSION_PY3 = "4.04.09"
+DPAR_UPDATELOG = "N813 - Custom asset name to publishing."
 
 
 


### PR DESCRIPTION
Implemented a feature to read the _dpPipeline/dpCustomAssetName.json file and get the name to save the published file if exists.