### PR TITLE
N834 Auto keyframe from ikFkSnap change issue fixed

### DIFF
--- a/dpAutoRigSystem/Modules/Library/dpIkFkSnap.py
+++ b/dpAutoRigSystem/Modules/Library/dpIkFkSnap.py
@@ -15,7 +15,7 @@ from maya.api import OpenMaya
 from ...Extras import dpCustomAttr
 import math
 
-DP_IKFKSNAP_VERSION = 2.0
+DP_IKFKSNAP_VERSION = 2.1
 
 
 
@@ -112,19 +112,20 @@ class IkFkSnapClass(object):
         """ Just call snap function to set as well.
         """
         self.worldRef = cmds.listConnections(self.ikFkSnapNet+".worldRef")[0]
-        self.ikFkState = cmds.getAttr(self.ikFkSnapNet+".ikFkState")
-        currentValue = cmds.getAttr(self.worldRef+"."+self.ikFkBlendAttr)
-        if self.ikFkState == 0: #ik
-            if currentValue >= 0.001:
-                self.changeIkFkAttr(0, False)
-                self.snapIkToFk()
-                self.changeIkFkAttr(1, True)
-        else: #fk
-            if currentValue < 0.999:
-                self.changeIkFkAttr(1, False)
-                self.snapFkToIk()
-                self.changeIkFkAttr(0, True)
-        self.resetShear(list(set([self.ikExtremCtrl] + self.fkCtrlList)))
+        if cmds.getAttr(self.worldRef+".ikFkSnap"):
+            self.ikFkState = cmds.getAttr(self.ikFkSnapNet+".ikFkState")
+            currentValue = cmds.getAttr(self.worldRef+"."+self.ikFkBlendAttr)
+            if self.ikFkState == 0: #ik
+                if currentValue >= 0.001:
+                    self.changeIkFkAttr(0, False)
+                    self.snapIkToFk()
+                    self.changeIkFkAttr(1, True)
+            else: #fk
+                if currentValue < 0.999:
+                    self.changeIkFkAttr(1, False)
+                    self.snapFkToIk()
+                    self.changeIkFkAttr(0, True)
+            self.resetShear(list(set([self.ikExtremCtrl] + self.fkCtrlList)))
 
 
     def changeIkFkAttr(self, ikFkValue, setState, *args):
@@ -144,60 +145,58 @@ class IkFkSnapClass(object):
     def snapIkToFk(self, *args):
         """ Switch from ik to fk keeping the same position.
         """
-        if cmds.getAttr(self.worldRef+".ikFkSnap"):
-            self.bakeFollowRotation(self.ikBeforeCtrl)
-            self.bakeFollowRotation(self.fkCtrlList[0])
-            self.transferAttrFromTo(self.ikExtremCtrl, self.fkCtrlList[2], [self.uniformScaleAttr])
-            # snap fk ctrl to ik jnt
-            for ctrl, jnt in zip(self.fkCtrlList, self.ikJointList):
-                cmds.xform(ctrl, matrix=(cmds.xform(jnt, matrix=True, query=True, worldSpace=True)), worldSpace=True)
-            
+        self.bakeFollowRotation(self.ikBeforeCtrl)
+        self.bakeFollowRotation(self.fkCtrlList[0])
+        self.transferAttrFromTo(self.ikExtremCtrl, self.fkCtrlList[2], [self.uniformScaleAttr])
+        # snap fk ctrl to ik jnt
+        for ctrl, jnt in zip(self.fkCtrlList, self.ikJointList):
+            cmds.xform(ctrl, matrix=(cmds.xform(jnt, matrix=True, query=True, worldSpace=True)), worldSpace=True)
+
 
     def snapFkToIk(self, *args):
         """ Switch from fk to ik keeping the same position.
         """
-        if cmds.getAttr(self.worldRef+".ikFkSnap"):
-            self.bakeFollowRotation(self.ikBeforeCtrl)
-            self.zeroKeyAttrValue(self.ikExtremCtrl, ["twist"])
-            self.zeroKeyAttrValue(self.ikExtremSubCtrl, ["tx", "ty", "tz", "rx", "ry", "rz"])
-            self.transferAttrFromTo(self.fkCtrlList[2], self.ikExtremCtrl, [self.uniformScaleAttr])
-            # extrem ctrl
-            fkM = OpenMaya.MMatrix(cmds.getAttr(self.fkCtrlList[-1]+".worldMatrix[0]"))
-            toIkM = OpenMaya.MMatrix(self.extremOffsetMatrix) * fkM #need redefine to load matrix in scriptNode
-            cmds.xform(self.ikExtremCtrl, matrix=list(toIkM), worldSpace=True)
-            # poleVector ctrl
-            startPos, cornerPos, endPos, chainLen, pvRatio = self.getChainPosition()
-            # calculate the position of the base middle locator
-            pvBasePosX = (endPos[0] - startPos[0]) * pvRatio+startPos[0]
-            pvBasePosY = (endPos[1] - startPos[1]) * pvRatio+startPos[1]
-            pvBasePosZ = (endPos[2] - startPos[2]) * pvRatio+startPos[2]
-            # working with vectors
-            cornerBasePosX = cornerPos[0] - pvBasePosX
-            cornerBasePosY = cornerPos[1] - pvBasePosY
-            cornerBasePosZ = cornerPos[2] - pvBasePosZ
-            # magnitude of the vector
-            magDir = math.sqrt(cornerBasePosX**2+cornerBasePosY**2+cornerBasePosZ**2)
-            # normalize the vector
-            normalDirX = cornerBasePosX / magDir
-            normalDirY = cornerBasePosY / magDir
-            normalDirZ = cornerBasePosZ / magDir
-            # calculate the poleVector position by multiplying the unitary vector by the chain length
-            pvDistX = normalDirX * chainLen
-            pvDistY = normalDirY * chainLen
-            pvDistZ = normalDirZ * chainLen
-            # get the poleVector position
-            pvPosX = pvBasePosX+pvDistX
-            pvPosY = pvBasePosY+pvDistY
-            pvPosZ = pvBasePosZ+pvDistZ
-            # place poleVector controller in the correct position
-            cmds.move(pvPosX, pvPosY, pvPosZ, self.ikPoleVectorCtrl, objectSpace=False, worldSpaceDistance=True)
-            # reset footRoll attributes
-            userDefAttrList = cmds.listAttr(self.ikExtremCtrl, userDefined=True, keyable=True)
-            if userDefAttrList:
-                for attr in userDefAttrList:
-                    for revFootAttr in self.revFootAttrList:
-                        if revFootAttr in attr:
-                            cmds.setAttr(self.ikExtremCtrl+"."+attr, 0)
+        self.bakeFollowRotation(self.ikBeforeCtrl)
+        self.zeroKeyAttrValue(self.ikExtremCtrl, ["twist"])
+        self.zeroKeyAttrValue(self.ikExtremSubCtrl, ["tx", "ty", "tz", "rx", "ry", "rz"])
+        self.transferAttrFromTo(self.fkCtrlList[2], self.ikExtremCtrl, [self.uniformScaleAttr])
+        # extrem ctrl
+        fkM = OpenMaya.MMatrix(cmds.getAttr(self.fkCtrlList[-1]+".worldMatrix[0]"))
+        toIkM = OpenMaya.MMatrix(self.extremOffsetMatrix) * fkM #need redefine to load matrix in scriptNode
+        cmds.xform(self.ikExtremCtrl, matrix=list(toIkM), worldSpace=True)
+        # poleVector ctrl
+        startPos, cornerPos, endPos, chainLen, pvRatio = self.getChainPosition()
+        # calculate the position of the base middle locator
+        pvBasePosX = (endPos[0] - startPos[0]) * pvRatio+startPos[0]
+        pvBasePosY = (endPos[1] - startPos[1]) * pvRatio+startPos[1]
+        pvBasePosZ = (endPos[2] - startPos[2]) * pvRatio+startPos[2]
+        # working with vectors
+        cornerBasePosX = cornerPos[0] - pvBasePosX
+        cornerBasePosY = cornerPos[1] - pvBasePosY
+        cornerBasePosZ = cornerPos[2] - pvBasePosZ
+        # magnitude of the vector
+        magDir = math.sqrt(cornerBasePosX**2+cornerBasePosY**2+cornerBasePosZ**2)
+        # normalize the vector
+        normalDirX = cornerBasePosX / magDir
+        normalDirY = cornerBasePosY / magDir
+        normalDirZ = cornerBasePosZ / magDir
+        # calculate the poleVector position by multiplying the unitary vector by the chain length
+        pvDistX = normalDirX * chainLen
+        pvDistY = normalDirY * chainLen
+        pvDistZ = normalDirZ * chainLen
+        # get the poleVector position
+        pvPosX = pvBasePosX+pvDistX
+        pvPosY = pvBasePosY+pvDistY
+        pvPosZ = pvBasePosZ+pvDistZ
+        # place poleVector controller in the correct position
+        cmds.move(pvPosX, pvPosY, pvPosZ, self.ikPoleVectorCtrl, objectSpace=False, worldSpaceDistance=True)
+        # reset footRoll attributes
+        userDefAttrList = cmds.listAttr(self.ikExtremCtrl, userDefined=True, keyable=True)
+        if userDefAttrList:
+            for attr in userDefAttrList:
+                for revFootAttr in self.revFootAttrList:
+                    if revFootAttr in attr:
+                        cmds.setAttr(self.ikExtremCtrl+"."+attr, 0)
 
 
     def getOffsetXform(self, wm, wim, *args):
@@ -333,19 +332,20 @@ class IkFkSnap(object):
         """ Just call snap function to set as well.
         """
         self.worldRef = cmds.listConnections(self.ikFkSnapNet+".worldRef")[0]
-        self.ikFkState = cmds.getAttr(self.ikFkSnapNet+".ikFkState")
-        currentValue = cmds.getAttr(self.worldRef+"."+self.ikFkBlendAttr)
-        if self.ikFkState == 0: #ik
-            if currentValue >= 0.001:
-                self.changeIkFkAttr(0, False)
-                self.snapIkToFk()
-                self.changeIkFkAttr(1, True)
-        else: #fk
-            if currentValue < 0.999:
-                self.changeIkFkAttr(1, False)
-                self.snapFkToIk()
-                self.changeIkFkAttr(0, True)
-        self.resetShear(list(set([self.ikExtremCtrl] + self.fkCtrlList)))
+        if cmds.getAttr(self.worldRef+".ikFkSnap"):
+            self.ikFkState = cmds.getAttr(self.ikFkSnapNet+".ikFkState")
+            currentValue = cmds.getAttr(self.worldRef+"."+self.ikFkBlendAttr)
+            if self.ikFkState == 0: #ik
+                if currentValue >= 0.001:
+                    self.changeIkFkAttr(0, False)
+                    self.snapIkToFk()
+                    self.changeIkFkAttr(1, True)
+            else: #fk
+                if currentValue < 0.999:
+                    self.changeIkFkAttr(1, False)
+                    self.snapFkToIk()
+                    self.changeIkFkAttr(0, True)
+            self.resetShear(list(set([self.ikExtremCtrl] + self.fkCtrlList)))
 
     def changeIkFkAttr(self, ikFkValue, setState, *args):
         """ 0 = ik
@@ -363,59 +363,57 @@ class IkFkSnap(object):
     def snapIkToFk(self, *args):
         """ Switch from ik to fk keeping the same position.
         """
-        if cmds.getAttr(self.worldRef+".ikFkSnap"):
-            self.bakeFollowRotation(self.ikBeforeCtrl)
-            self.bakeFollowRotation(self.fkCtrlList[0])
-            self.transferAttrFromTo(self.ikExtremCtrl, self.fkCtrlList[2], [self.uniformScaleAttr])
-            # snap fk ctrl to ik jnt
-            for ctrl, jnt in zip(self.fkCtrlList, self.ikJointList):
-                cmds.xform(ctrl, matrix=(cmds.xform(jnt, matrix=True, query=True, worldSpace=True)), worldSpace=True)
+        self.bakeFollowRotation(self.ikBeforeCtrl)
+        self.bakeFollowRotation(self.fkCtrlList[0])
+        self.transferAttrFromTo(self.ikExtremCtrl, self.fkCtrlList[2], [self.uniformScaleAttr])
+        # snap fk ctrl to ik jnt
+        for ctrl, jnt in zip(self.fkCtrlList, self.ikJointList):
+            cmds.xform(ctrl, matrix=(cmds.xform(jnt, matrix=True, query=True, worldSpace=True)), worldSpace=True)
     
     def snapFkToIk(self, *args):
         """ Switch from fk to ik keeping the same position.
         """
-        if cmds.getAttr(self.worldRef+".ikFkSnap"):
-            self.bakeFollowRotation(self.ikBeforeCtrl)
-            self.zeroKeyAttrValue(self.ikExtremCtrl, ["twist"])
-            self.zeroKeyAttrValue(self.ikExtremSubCtrl, ["tx", "ty", "tz", "rx", "ry", "rz"])
-            self.transferAttrFromTo(self.fkCtrlList[2], self.ikExtremCtrl, [self.uniformScaleAttr])
-            # extrem ctrl
-            fkM = OpenMaya.MMatrix(cmds.getAttr(self.fkCtrlList[-1]+".worldMatrix[0]"))
-            toIkM = OpenMaya.MMatrix(self.extremOffsetMatrix) * fkM
-            cmds.xform(self.ikExtremCtrl, matrix=list(toIkM), worldSpace=True)
-            # poleVector ctrl
-            startPos, cornerPos, endPos, chainLen, pvRatio = self.getChainPosition()
-            # calculate the position of the base middle locator
-            pvBasePosX = (endPos[0] - startPos[0]) * pvRatio+startPos[0]
-            pvBasePosY = (endPos[1] - startPos[1]) * pvRatio+startPos[1]
-            pvBasePosZ = (endPos[2] - startPos[2]) * pvRatio+startPos[2]
-            # working with vectors
-            cornerBasePosX = cornerPos[0] - pvBasePosX
-            cornerBasePosY = cornerPos[1] - pvBasePosY
-            cornerBasePosZ = cornerPos[2] - pvBasePosZ
-            # magnitude of the vector
-            magDir = math.sqrt(cornerBasePosX**2+cornerBasePosY**2+cornerBasePosZ**2)
-            # normalize the vector
-            normalDirX = cornerBasePosX / magDir
-            normalDirY = cornerBasePosY / magDir
-            normalDirZ = cornerBasePosZ / magDir
-            # calculate the poleVector position by multiplying the unitary vector by the chain length
-            pvDistX = normalDirX * chainLen
-            pvDistY = normalDirY * chainLen
-            pvDistZ = normalDirZ * chainLen
-            # get the poleVector position
-            pvPosX = pvBasePosX+pvDistX
-            pvPosY = pvBasePosY+pvDistY
-            pvPosZ = pvBasePosZ+pvDistZ
-            # place poleVector controller in the correct position
-            cmds.move(pvPosX, pvPosY, pvPosZ, self.ikPoleVectorCtrl, objectSpace=False, worldSpaceDistance=True)
-            # reset footRoll attributes
-            userDefAttrList = cmds.listAttr(self.ikExtremCtrl, userDefined=True, keyable=True)
-            if userDefAttrList:
-                for attr in userDefAttrList:
-                    for revFootAttr in self.revFootAttrList:
-                        if revFootAttr in attr:
-                            cmds.setAttr(self.ikExtremCtrl+"."+attr, 0)
+        self.bakeFollowRotation(self.ikBeforeCtrl)
+        self.zeroKeyAttrValue(self.ikExtremCtrl, ["twist"])
+        self.zeroKeyAttrValue(self.ikExtremSubCtrl, ["tx", "ty", "tz", "rx", "ry", "rz"])
+        self.transferAttrFromTo(self.fkCtrlList[2], self.ikExtremCtrl, [self.uniformScaleAttr])
+        # extrem ctrl
+        fkM = OpenMaya.MMatrix(cmds.getAttr(self.fkCtrlList[-1]+".worldMatrix[0]"))
+        toIkM = OpenMaya.MMatrix(self.extremOffsetMatrix) * fkM
+        cmds.xform(self.ikExtremCtrl, matrix=list(toIkM), worldSpace=True)
+        # poleVector ctrl
+        startPos, cornerPos, endPos, chainLen, pvRatio = self.getChainPosition()
+        # calculate the position of the base middle locator
+        pvBasePosX = (endPos[0] - startPos[0]) * pvRatio+startPos[0]
+        pvBasePosY = (endPos[1] - startPos[1]) * pvRatio+startPos[1]
+        pvBasePosZ = (endPos[2] - startPos[2]) * pvRatio+startPos[2]
+        # working with vectors
+        cornerBasePosX = cornerPos[0] - pvBasePosX
+        cornerBasePosY = cornerPos[1] - pvBasePosY
+        cornerBasePosZ = cornerPos[2] - pvBasePosZ
+        # magnitude of the vector
+        magDir = math.sqrt(cornerBasePosX**2+cornerBasePosY**2+cornerBasePosZ**2)
+        # normalize the vector
+        normalDirX = cornerBasePosX / magDir
+        normalDirY = cornerBasePosY / magDir
+        normalDirZ = cornerBasePosZ / magDir
+        # calculate the poleVector position by multiplying the unitary vector by the chain length
+        pvDistX = normalDirX * chainLen
+        pvDistY = normalDirY * chainLen
+        pvDistZ = normalDirZ * chainLen
+        # get the poleVector position
+        pvPosX = pvBasePosX+pvDistX
+        pvPosY = pvBasePosY+pvDistY
+        pvPosZ = pvBasePosZ+pvDistZ
+        # place poleVector controller in the correct position
+        cmds.move(pvPosX, pvPosY, pvPosZ, self.ikPoleVectorCtrl, objectSpace=False, worldSpaceDistance=True)
+        # reset footRoll attributes
+        userDefAttrList = cmds.listAttr(self.ikExtremCtrl, userDefined=True, keyable=True)
+        if userDefAttrList:
+            for attr in userDefAttrList:
+                for revFootAttr in self.revFootAttrList:
+                    if revFootAttr in attr:
+                        cmds.setAttr(self.ikExtremCtrl+"."+attr, 0)
 
     def getOffsetXform(self, wm, wim, *args):
         """ Return the offset xform matrix (multiplied matrices) from given xform matrices.

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -18,8 +18,8 @@
 ###################################################################
 
 
-DPAR_VERSION_PY3 = "4.04.14"
-DPAR_UPDATELOG = "N228 - Scalable Spine."
+DPAR_VERSION_PY3 = "4.04.15"
+DPAR_UPDATELOG = "N834 - Auto keyframe from IkFk change issue."
 
 
 


### PR DESCRIPTION
Deactivating ikFkSnap scriptNode if the OptionCtrl ikFkSnap attribute is zero. This is an workround to not have keyframes in the timeline when the ikFkSnap is off.