### PR TITLE
826 root pivot ctrl parenting

### DIFF
--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -2165,6 +2165,7 @@ class DP_AutoRig_UI(object):
         if (self.ctrlCreated):
             self.rootPivotCtrlGrp = dpUtils.zeroOut([self.rootPivotCtrl])[0]
             cmds.parent(self.rootPivotCtrlGrp, self.rootCtrl)
+            self.changeRootToCtrlsVisConstraint()
         self.optionCtrl = self.getBaseCtrl("id_006_Option", "optionCtrl", self.prefix+"Option_Ctrl", self.ctrls.dpCheckLinearUnit(16))
         if (self.ctrlCreated):
             cmds.makeIdentity(self.optionCtrl, apply=True)
@@ -2220,7 +2221,18 @@ class DP_AutoRig_UI(object):
             cmds.scaleConstraint(self.rootCtrl, self.baseRootJntGrp, maintainOffset=True, name=self.baseRootJntGrp+"_ScC")
             cmds.setAttr(self.baseRootJntGrp+".visibility", 0)
             self.ctrls.setLockHide([self.baseRootJnt, self.baseRootJntGrp], ['tx', 'ty', 'tz', 'rx', 'ry', 'rz', 'sx', 'sy', 'sz', 'v'])
-        
+    
+
+    def changeRootToCtrlsVisConstraint(self, *args):
+        """ Just recreate the Root_Ctrl output connections to a constraint, now using the ctrlsVisibilityGrp as source node instead.
+            It keeps the dpAR compatibility to old rigs.
+        """
+        changeAttrList = ["rotateOrder", "translate", "rotate", "scale", "parentMatrix[0]", "rotatePivot", "rotatePivotTranslate"]
+        for attr in changeAttrList:
+            pacList = cmds.listConnections(self.rootCtrl+"."+attr, destination=True, source=False, plugs=True)
+            for pac in pacList:
+                cmds.connectAttr(self.ctrlsVisGrp+"."+attr, pac, force=True)
+
 
     def validateMasterGrp(self, nodeGrp, *args):
         """ Check if the current nodeGrp is a valid masterGrp (All_Grp) verifying it's message attribute connections.

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -2230,8 +2230,9 @@ class DP_AutoRig_UI(object):
         changeAttrList = ["rotateOrder", "translate", "rotate", "scale", "parentMatrix[0]", "rotatePivot", "rotatePivotTranslate"]
         for attr in changeAttrList:
             pacList = cmds.listConnections(self.rootCtrl+"."+attr, destination=True, source=False, plugs=True)
-            for pac in pacList:
-                cmds.connectAttr(self.ctrlsVisGrp+"."+attr, pac, force=True)
+            if pacList:
+                for pac in pacList:
+                    cmds.connectAttr(self.ctrlsVisGrp+"."+attr, pac, force=True)
 
 
     def validateMasterGrp(self, nodeGrp, *args):

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -18,8 +18,8 @@
 ###################################################################
 
 
-DPAR_VERSION_PY3 = "4.04.17"
-DPAR_UPDATELOG = "N819- Try/except add or remove skinCluster influence."
+DPAR_VERSION_PY3 = "4.04.18"
+DPAR_UPDATELOG = "N826 - RootPivot_Ctrl parenting."
 
 
 
@@ -2162,11 +2162,13 @@ class DP_AutoRig_UI(object):
         self.globalCtrl = self.getBaseCtrl("id_003_Global", "globalCtrl", self.prefix+"Global_Ctrl", self.ctrls.dpCheckLinearUnit(13))
         self.rootCtrl   = self.getBaseCtrl("id_005_Root", "rootCtrl", self.prefix+"Root_Ctrl", self.ctrls.dpCheckLinearUnit(8))
         self.rootPivotCtrl = self.getBaseCtrl("id_099_RootPivot", "rootPivotCtrl", self.prefix+"Root_Pivot_Ctrl", self.ctrls.dpCheckLinearUnit(1), iDegree=3)
+        if (self.ctrlCreated):
+            self.rootPivotCtrlGrp = dpUtils.zeroOut([self.rootPivotCtrl])[0]
+            cmds.parent(self.rootPivotCtrlGrp, self.rootCtrl)
         self.optionCtrl = self.getBaseCtrl("id_006_Option", "optionCtrl", self.prefix+"Option_Ctrl", self.ctrls.dpCheckLinearUnit(16))
         if (self.ctrlCreated):
             cmds.makeIdentity(self.optionCtrl, apply=True)
             self.optionCtrlGrp = dpUtils.zeroOut([self.optionCtrl])[0]
-            self.rootPivotCtrlGrp = dpUtils.zeroOut([self.rootPivotCtrl])[0]
             cmds.setAttr(self.optionCtrlGrp+".translateX", fMasterRadius)
             # use Option_Ctrl rigScale and rigScaleMultiplier attribute to Master_Ctrl
             self.rigScaleMD = cmds.createNode("multiplyDivide", name=self.prefix+'RigScale_MD')
@@ -2184,7 +2186,6 @@ class DP_AutoRig_UI(object):
             self.ctrls.setLockHide([self.optionCtrl], ['rigScaleOutput'])
             self.ctrls.setNonKeyable([self.optionCtrl], ['tx', 'ty', 'tz', 'rx', 'ry', 'rz', 'sx', 'sy', 'sz', 'v'])
             self.ctrls.setCalibrationAttr(self.optionCtrl, ['rigScaleMultiplier'])
-            cmds.parent(self.rootPivotCtrlGrp, self.rootCtrl)
             cmds.parent(self.rootCtrl, self.masterCtrl)
             cmds.parent(self.masterCtrl, self.globalCtrl)
             cmds.parent(self.globalCtrl, self.ctrlsGrp)


### PR DESCRIPTION
Correcting error when try to create new guides in old rigs.