### PR TITLE
N899 - Reconnect attributes after copy skin weights

### DIFF
--- a/dpAutoRigSystem/Modules/Library/dpSkinning.py
+++ b/dpAutoRigSystem/Modules/Library/dpSkinning.py
@@ -3,7 +3,7 @@ from maya import cmds
 from maya import mel
 from . import dpWeights
 
-DP_SKINNING_VERSION = 1.6
+DP_SKINNING_VERSION = 1.7
 
 
 class Skinning(dpWeights.Weights):
@@ -175,6 +175,14 @@ class Skinning(dpWeights.Weights):
                     newSkinClusterNode = cmds.skinCluster(skinInfList, destinationItem, multi=True, name=skinClusterName+"_"+str(i)+"_SC", toSelectedBones=True, maximumInfluences=3, skinMethod=skinMethodToUse)[0]
                 cmds.rename(cmds.listConnections(newSkinClusterNode+".bindPose", destination=False, source=True), newSkinClusterNode.replace("_SC", "_BP"))
                 self.setSkinRelativeMode(newSkinClusterNode)
+                if not skinMethodToUse == 0:
+                    if cmds.getAttr(sourceDef+".dqsSupportNonRigid"):
+                        cmds.setAttr(newSkinClusterNode+".dqsSupportNonRigid", 1)
+                        plug = cmds.listConnections(sourceDef+".dqsScaleX", destination=False, source=True, plugs=True)
+                        if plug:
+                            cmds.connectAttr(plug[0], newSkinClusterNode+".dqsScaleX", force=True)
+                            cmds.connectAttr(plug[0], newSkinClusterNode+".dqsScaleY", force=True)
+                            cmds.connectAttr(plug[0], newSkinClusterNode+".dqsScaleZ", force=True)
                 # copy skin weights from source to destination
                 if byUVs:
                     sourceUVMap = cmds.polyUVSet(sourceItem, query=True, allUVSets=True)[0]

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -18,8 +18,8 @@
 ###################################################################
 
 
-DPAR_VERSION_5 = "5.00.09"
-DPAR_UPDATELOG = "N253 - Fixed mirror pinned guide issue."
+DPAR_VERSION_5 = "5.00.10"
+DPAR_UPDATELOG = "N899 - Reconnect attributes after copy skinning weights."
 
 # to make old dpAR version compatible to receive this update message - it can be deleted in the future 
 DPAR_VERSION_PY3 = "5.00.00 - ATTENTION !!!\n\nThere's a new dpAutoRigSystem released version.\nBut it isn't compatible with this current version 4, sorry.\nYou must download and replace all files manually.\nPlease, delete the folder and copy the new one.\nAlso, recreate your shelf button with the given code in the _shelfButton.txt\nThanks."


### PR DESCRIPTION
Just reconnecting attributes after copy skinning weights of dual quaternion mode if there's connected scale values.