### PR TITLE
N828 - Proxy without sets

### DIFF
--- a/dpAutoRigSystem/Modules/Library/dpUtils.py
+++ b/dpAutoRigSystem/Modules/Library/dpUtils.py
@@ -17,7 +17,7 @@ import unicodedata
 from io import TextIOWrapper
 from importlib import reload
 
-DP_UTILS_VERSION = 3.4
+DP_UTILS_VERSION = 3.5
 
 
 class Utils(object):
@@ -1544,3 +1544,18 @@ class Utils(object):
         childrenGuideList = self.getGuideChildrenList(node)
         if childrenGuideList:
             cmds.parent(childrenGuideList, dest)
+
+
+    def removeFromSets(self, item, *args):
+        """ Remove the given node from existing sets.
+        """
+        if cmds.objExists(item):
+            setList = cmds.listSets(object=item, extendToShape=True)
+            renderSetList = cmds.listSets(object=item, extendToShape=True, type=1) #rendering sets
+            setList = list(set(setList)-set(renderSetList))
+            if setList:
+                for setNode in setList:
+                    cmds.sets(item, remove=setNode)
+                    cmds.sets(item+".vtx[*]", remove=setNode)
+                    cmds.sets(item+".f[*]", remove=setNode)
+                    cmds.sets(item+".e[*]", remove=setNode)

--- a/dpAutoRigSystem/Pipeline/Validator/CheckOut/dpProxyCreator.py
+++ b/dpAutoRigSystem/Pipeline/Validator/CheckOut/dpProxyCreator.py
@@ -11,7 +11,7 @@ ICON = "/Icons/dp_proxyCreator.png"
 PROXIED = "dpProxied"
 NO_PROXY = "dpDoNotProxyIt"
 
-DP_PROXYCREATOR_VERSION = 1.5
+DP_PROXYCREATOR_VERSION = 1.6
 
 
 class ProxyCreator(dpBaseAction.ActionStartClass):
@@ -163,6 +163,7 @@ class ProxyCreator(dpBaseAction.ActionStartClass):
                         self.repeatedNameList.append(shortName)
                         self.utils.removeUserDefinedAttr(dup)
                         self.utils.deleteOrigShape(dup)
+                        self.utils.removeFromSets(dup)
                         if nodeFaceList:
                             faceDupList = [w.replace(source, dup) for w in nodeFaceList]
                             cmds.delete(faceDupList)

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -18,8 +18,8 @@
 ###################################################################
 
 
-DPAR_VERSION_5 = "5.00.37"
-DPAR_UPDATELOG = "N919 - Adjust Prune validator factor calibrate."
+DPAR_VERSION_5 = "5.00.38"
+DPAR_UPDATELOG = "N828 - Proxy without sets."
 
 # to make old dpAR version compatible to receive this update message - it can be deleted in the future 
 DPAR_VERSION_PY3 = "5.00.00 - ATTENTION !!!\n\nThere's a new dpAutoRigSystem released version.\nBut it isn't compatible with this current version 4, sorry.\nYou must download and replace all files manually.\nPlease, delete the folder and copy the new one.\nAlso, recreate your shelf button with the given code in the _shelfButton.txt\nThanks."


### PR DESCRIPTION
Added a new method in the dpUtils to removeFromSets. Call this method when ProxyCreator duplicates the mesh to cleanup it from sets.