### PR TITLE
N933 - KeepIt from EmptyTransformCleaner

### DIFF
--- a/dpAutoRigSystem/Pipeline/Validator/CheckOut/dpEmptyTransformCleaner.py
+++ b/dpAutoRigSystem/Pipeline/Validator/CheckOut/dpEmptyTransformCleaner.py
@@ -9,7 +9,7 @@ DESCRIPTION = "v139_emptyTransformCleanerDesc"
 ICON = "/Icons/dp_emptyTransformCleaner.png"
 WIKI = "07-‐-Validator#-empty-transform-cleaner"
 
-DP_EMPTYTRANSFORMCLEANER_VERSION = 1.01
+DP_EMPTYTRANSFORMCLEANER_VERSION = 1.02
 
 
 class EmptyTransformCleaner(dpBaseAction.ActionStartClass):
@@ -43,7 +43,7 @@ class EmptyTransformCleaner(dpBaseAction.ActionStartClass):
             if objList:
                 toCheckList = objList
             else:
-                toCheckList =  cmds.ls(selection=False, long=True, type="transform") #list all transforms in the scene
+                toCheckList = cmds.ls(selection=False, long=True, type="transform") #list all transforms in the scene
             if toCheckList:
                 self.utils.setProgress(max=len(toCheckList), addOne=False, addNumber=False)
                 emptyTransformList = self.filterEmptyTransformList(toCheckList)
@@ -58,8 +58,11 @@ class EmptyTransformCleaner(dpBaseAction.ActionStartClass):
                             self.resultOkList.append(False)
                         else: #fix
                             try:
-                                cmds.lockNode(item, lock=False)
-                                cmds.delete(item)
+                                if "dpKeepIt" in cmds.listAttr(item) and cmds.getAttr(item+".dpKeepIt") == True:
+                                    pass
+                                else:
+                                    cmds.lockNode(item, lock=False)
+                                    cmds.delete(item)
                                 self.resultOkList.append(True)
                                 self.messageList.append(self.dpUIinst.lang['v004_fixed']+": "+item)
                             except:

--- a/dpAutoRigSystem/dpAutoRig.py
+++ b/dpAutoRigSystem/dpAutoRig.py
@@ -18,8 +18,8 @@
 ###################################################################
 
 
-DPAR_VERSION_5 = "5.01.48"
-DPAR_UPDATELOG = "N992 - Mocap definition for simple rigs."
+DPAR_VERSION_5 = "5.01.49"
+DPAR_UPDATELOG = "N993 - KeepIt to EmptyTransform checkout validator."
 
 # to make old dpAR version compatible to receive this update message - it can be deleted in the future 
 DPAR_VERSION_PY3 = "5.00.00 - ATTENTION !!!\n\nThere's a new dpAutoRigSystem released version.\nBut it isn't compatible with this current version 4, sorry.\nYou must download and replace all files manually.\nPlease, delete the folder and copy the new one.\nAlso, recreate your shelf button with the given code in the _shelfButton.txt\nThanks."


### PR DESCRIPTION
EmptyTransformCleaner checkout validator must respect the dpKeepIt attribute even if the node is empty.